### PR TITLE
chore: ignore local vscode settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -125,6 +125,9 @@ dist
 # Stores VSCode versions used for testing VSCode extensions
 .vscode-test
 
+# Local VS Code window color settings (personal preference)
+.vscode/settings.json
+
 # yarn v3
 .pnp.*
 .yarn/*


### PR DESCRIPTION
Add .vscode/settings.json to .gitignore — personal window color settings, not for sharing.