### PR TITLE
feat: add Stripe webhook handler for payment and refund events #71

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,6 +25,6 @@ AWS_SECRET_ACCESS_KEY=
 AWS_S3_BUCKET=
 
 # ─── Stripe (filled during W6 — Payments) ────────────────────────────────────
-STRIPE_SECRET_KEY=
-STRIPE_WEBHOOK_SECRET=
-NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=
+STRIPE_SECRET_KEY=sk_test_your_stripe_secret_key_here
+STRIPE_WEBHOOK_SECRET=whsec_your_webhook_signing_secret_here
+NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=pk_test_your_stripe_publishable_key_here

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -33,7 +33,7 @@ AWS_S3_BUCKET=
 # 3. Перейди: Developers → API keys
 # 4. Скопируй "Secret key" (начинается с sk_test_...)
 #    НИКОГДА не используй sk_live_... в .env для локальной разработки!
-STRIPE_SECRET_KEY=
+STRIPE_SECRET_KEY=sk_test_your_stripe_secret_key_here
 #
 # ── STRIPE_WEBHOOK_SECRET — два варианта ──────────────────────────────────────
 #
@@ -58,4 +58,4 @@ STRIPE_SECRET_KEY=
 #   4. После создания: нажми "Reveal" в поле "Signing secret" → скопируй whsec_...
 #   5. Добавь в переменные окружения сервера (НЕ в .env файл в репозитории!)
 #
-STRIPE_WEBHOOK_SECRET=
+STRIPE_WEBHOOK_SECRET=whsec_your_webhook_signing_secret_here

--- a/apps/api/src/orders/orders.service.ts
+++ b/apps/api/src/orders/orders.service.ts
@@ -1,6 +1,6 @@
-import { BadRequestException, Injectable, NotFoundException } from '@nestjs/common'
+import { BadRequestException, Injectable, Logger, NotFoundException } from '@nestjs/common'
+import { OrderStatus, Prisma } from '@prisma/client'
 import { InputJsonValue } from '@prisma/client/runtime/library'
-import { OrderStatus } from '@prisma/client'
 import { PrismaService } from '../prisma/prisma.service'
 import { CreateOrderDto } from './dto/create-order.dto'
 import { OrderQueryDto } from './dto/order-query.dto'
@@ -9,46 +9,66 @@ import { isValidOrderStatusTransition } from './order-status.transitions'
 
 @Injectable()
 export class OrdersService {
+  private readonly logger = new Logger(OrdersService.name)
+
   constructor(private readonly prismaService: PrismaService) {}
 
   async create(createOrderDto: CreateOrderDto) {
     const { items, shippingAddress, userId, guestEmail, subtotal, shippingCost, total, source } =
       createOrderDto
 
-    const order = await this.prismaService.order.create({
-      data: {
-        userId: userId ?? null,
-        guestEmail: guestEmail ?? null,
-        subtotal,
-        shippingCost,
-        total,
-        shippingAddress: shippingAddress as unknown as InputJsonValue,
-        source: source ?? 'web',
-        status: OrderStatus.PENDING,
-        items: {
-          create: items.map((orderItem) => ({
-            productId: orderItem.productId,
-            quantity: orderItem.quantity,
-            price: orderItem.price,
-            productSnapshot: orderItem.productSnapshot,
-          })),
-        },
-        // Record initial PENDING status in history for full audit trail
-        statusHistory: {
-          create: {
-            fromStatus: null,
-            toStatus: OrderStatus.PENDING,
-            createdBy: userId ?? guestEmail ?? 'guest',
+    try {
+      const order = await this.prismaService.order.create({
+        data: {
+          userId: userId ?? null,
+          guestEmail: guestEmail ?? null,
+          subtotal,
+          shippingCost,
+          total,
+          shippingAddress: shippingAddress as unknown as InputJsonValue,
+          source: source ?? 'web',
+          status: OrderStatus.PENDING,
+          items: {
+            create: items.map((orderItem) => ({
+              productId: orderItem.productId,
+              quantity: orderItem.quantity,
+              price: orderItem.price,
+              productSnapshot: orderItem.productSnapshot,
+            })),
+          },
+          // Record initial PENDING status in history for full audit trail
+          statusHistory: {
+            create: {
+              fromStatus: null,
+              toStatus: OrderStatus.PENDING,
+              createdBy: userId ?? guestEmail ?? 'guest',
+            },
           },
         },
-      },
-      include: {
-        items: true,
-        statusHistory: true,
-      },
-    })
+        include: {
+          items: true,
+          statusHistory: true,
+        },
+      })
 
-    return order
+      return order
+    } catch (error) {
+      if (error instanceof Prisma.PrismaClientKnownRequestError) {
+        // P2003 = Foreign key constraint failed (e.g. productId does not exist)
+        if (error.code === 'P2003') {
+          const field = error.meta?.field_name ?? 'unknown field'
+          this.logger.warn(`Order creation failed — foreign key constraint on ${field}`)
+          throw new BadRequestException(
+            `One or more items reference a product that does not exist (${field})`,
+          )
+        }
+        // P2025 = Record not found
+        if (error.code === 'P2025') {
+          throw new BadRequestException('One or more referenced records do not exist')
+        }
+      }
+      throw error
+    }
   }
 
   async findAll(orderQueryDto: OrderQueryDto) {

--- a/apps/api/src/stripe/stripe-webhooks.controller.spec.ts
+++ b/apps/api/src/stripe/stripe-webhooks.controller.spec.ts
@@ -5,21 +5,38 @@ import type { RawBodyRequest } from '@nestjs/common'
 import Stripe from 'stripe'
 import { StripeWebhooksController } from './stripe-webhooks.controller'
 import { StripeService } from './stripe.service'
+import { StripeWebhooksService } from './stripe-webhooks.service'
 
 const FAKE_STRIPE_SIGNATURE = 't=1234,v1=abcdef'
 
 describe('StripeWebhooksController', () => {
   let stripeWebhooksController: StripeWebhooksController
   let mockStripeService: jest.Mocked<Pick<StripeService, 'constructWebhookEvent'>>
+  let mockStripeWebhooksService: jest.Mocked<
+    Pick<
+      StripeWebhooksService,
+      | 'handlePaymentIntentSucceeded'
+      | 'handlePaymentIntentFailed'
+      | 'handleChargeRefunded'
+      | 'handleChargeDisputeCreated'
+    >
+  >
 
   beforeEach(async () => {
-    mockStripeService = {
-      constructWebhookEvent: jest.fn(),
+    mockStripeService = { constructWebhookEvent: jest.fn() }
+    mockStripeWebhooksService = {
+      handlePaymentIntentSucceeded: jest.fn().mockResolvedValue(undefined),
+      handlePaymentIntentFailed: jest.fn().mockResolvedValue(undefined),
+      handleChargeRefunded: jest.fn().mockResolvedValue(undefined),
+      handleChargeDisputeCreated: jest.fn(),
     }
 
     const module: TestingModule = await Test.createTestingModule({
       controllers: [StripeWebhooksController],
-      providers: [{ provide: StripeService, useValue: mockStripeService }],
+      providers: [
+        { provide: StripeService, useValue: mockStripeService },
+        { provide: StripeWebhooksService, useValue: mockStripeWebhooksService },
+      ],
     }).compile()
 
     stripeWebhooksController = module.get<StripeWebhooksController>(StripeWebhooksController)
@@ -28,42 +45,110 @@ describe('StripeWebhooksController', () => {
   const buildFakeRequest = (rawBody?: Buffer): RawBodyRequest<Request> =>
     ({ rawBody }) as RawBodyRequest<Request>
 
-  it('returns { received: true } when the signature is valid', () => {
-    const fakeEvent = { id: 'evt_test', type: 'payment_intent.succeeded' } as Stripe.Event
-    const rawBody = Buffer.from('{"id":"evt_test"}')
+  it('returns { received: true } and dispatches payment_intent.succeeded', async () => {
+    const fakeEvent = {
+      id: 'evt_test',
+      type: 'payment_intent.succeeded',
+      data: { object: { id: 'pi_test' } },
+    } as unknown as Stripe.Event
+    const rawBody = Buffer.from('{}')
     mockStripeService.constructWebhookEvent.mockReturnValueOnce(fakeEvent)
 
-    const result = stripeWebhooksController.handleStripeWebhook(
+    const result = await stripeWebhooksController.handleStripeWebhook(
       buildFakeRequest(rawBody),
       FAKE_STRIPE_SIGNATURE,
     )
 
     expect(result).toEqual({ received: true })
-    expect(mockStripeService.constructWebhookEvent).toHaveBeenCalledWith(
-      rawBody,
-      FAKE_STRIPE_SIGNATURE,
+    expect(mockStripeWebhooksService.handlePaymentIntentSucceeded).toHaveBeenCalledWith(
+      fakeEvent.data.object,
     )
   })
 
-  it('throws BadRequestException when rawBody is missing', () => {
-    expect(() =>
-      stripeWebhooksController.handleStripeWebhook(buildFakeRequest(), FAKE_STRIPE_SIGNATURE),
-    ).toThrow(BadRequestException)
+  it('dispatches payment_intent.payment_failed', async () => {
+    const fakeEvent = {
+      type: 'payment_intent.payment_failed',
+      data: { object: { id: 'pi_test' } },
+    } as unknown as Stripe.Event
+    mockStripeService.constructWebhookEvent.mockReturnValueOnce(fakeEvent)
+
+    await stripeWebhooksController.handleStripeWebhook(
+      buildFakeRequest(Buffer.from('{}')),
+      FAKE_STRIPE_SIGNATURE,
+    )
+
+    expect(mockStripeWebhooksService.handlePaymentIntentFailed).toHaveBeenCalledWith(
+      fakeEvent.data.object,
+    )
   })
 
-  it('propagates StripeSignatureVerificationError when the signature is invalid', () => {
-    const rawBody = Buffer.from('{"id":"evt_test"}')
+  it('dispatches charge.refunded', async () => {
+    const fakeEvent = {
+      type: 'charge.refunded',
+      data: { object: { id: 'ch_test' } },
+    } as unknown as Stripe.Event
+    mockStripeService.constructWebhookEvent.mockReturnValueOnce(fakeEvent)
+
+    await stripeWebhooksController.handleStripeWebhook(
+      buildFakeRequest(Buffer.from('{}')),
+      FAKE_STRIPE_SIGNATURE,
+    )
+
+    expect(mockStripeWebhooksService.handleChargeRefunded).toHaveBeenCalledWith(
+      fakeEvent.data.object,
+    )
+  })
+
+  it('dispatches charge.dispute.created', async () => {
+    const fakeEvent = {
+      type: 'charge.dispute.created',
+      data: { object: { id: 'dp_test' } },
+    } as unknown as Stripe.Event
+    mockStripeService.constructWebhookEvent.mockReturnValueOnce(fakeEvent)
+
+    await stripeWebhooksController.handleStripeWebhook(
+      buildFakeRequest(Buffer.from('{}')),
+      FAKE_STRIPE_SIGNATURE,
+    )
+
+    expect(mockStripeWebhooksService.handleChargeDisputeCreated).toHaveBeenCalledWith(
+      fakeEvent.data.object,
+    )
+  })
+
+  it('returns { received: true } for unhandled event types', async () => {
+    const fakeEvent = {
+      type: 'customer.created',
+      data: { object: {} },
+    } as unknown as Stripe.Event
+    mockStripeService.constructWebhookEvent.mockReturnValueOnce(fakeEvent)
+
+    const result = await stripeWebhooksController.handleStripeWebhook(
+      buildFakeRequest(Buffer.from('{}')),
+      FAKE_STRIPE_SIGNATURE,
+    )
+
+    expect(result).toEqual({ received: true })
+  })
+
+  it('throws BadRequestException when rawBody is missing', async () => {
+    await expect(
+      stripeWebhooksController.handleStripeWebhook(buildFakeRequest(), FAKE_STRIPE_SIGNATURE),
+    ).rejects.toThrow(BadRequestException)
+  })
+
+  it('propagates StripeSignatureVerificationError when the signature is invalid', async () => {
+    const rawBody = Buffer.from('{}')
     mockStripeService.constructWebhookEvent.mockImplementationOnce(() => {
       throw new Stripe.errors.StripeSignatureVerificationError({
-        // 'invalid_request_error' is the closest built-in RawErrorType for signature errors
         type: 'invalid_request_error',
         message: 'No signatures found matching the expected signature for payload',
         detail: '',
       })
     })
 
-    expect(() =>
+    await expect(
       stripeWebhooksController.handleStripeWebhook(buildFakeRequest(rawBody), 'bad_signature'),
-    ).toThrow(Stripe.errors.StripeSignatureVerificationError)
+    ).rejects.toThrow(Stripe.errors.StripeSignatureVerificationError)
   })
 })

--- a/apps/api/src/stripe/stripe-webhooks.controller.ts
+++ b/apps/api/src/stripe/stripe-webhooks.controller.ts
@@ -9,26 +9,64 @@ import {
   Req,
 } from '@nestjs/common'
 import type { Request } from 'express'
+import type Stripe from 'stripe'
 import { StripeService } from './stripe.service'
+import { StripeWebhooksService } from './stripe-webhooks.service'
 
 @Controller('webhooks/stripe')
 export class StripeWebhooksController {
-  constructor(private readonly stripeService: StripeService) {}
+  constructor(
+    private readonly stripeService: StripeService,
+    private readonly stripeWebhooksService: StripeWebhooksService,
+  ) {}
 
   @Post()
   @HttpCode(HttpStatus.OK)
-  handleStripeWebhook(
+  async handleStripeWebhook(
     @Req() request: RawBodyRequest<Request>,
     @Headers('stripe-signature') stripeSignature: string,
-  ): { received: boolean } {
+  ): Promise<{ received: boolean }> {
     if (!request.rawBody) {
       throw new BadRequestException('Missing raw request body')
     }
 
-    // Throws StripeSignatureVerificationError → caught by HttpExceptionFilter as 400
-    this.stripeService.constructWebhookEvent(request.rawBody, stripeSignature)
+    // Throws StripeSignatureVerificationError if the signature is invalid
+    const stripeEvent = this.stripeService.constructWebhookEvent(request.rawBody, stripeSignature)
 
-    // Full event handling (payment_intent.succeeded etc.) is implemented in #71
+    await this.dispatchStripeEvent(stripeEvent)
+
     return { received: true }
+  }
+
+  private async dispatchStripeEvent(stripeEvent: Stripe.Event): Promise<void> {
+    switch (stripeEvent.type) {
+      case 'payment_intent.succeeded':
+        await this.stripeWebhooksService.handlePaymentIntentSucceeded(
+          stripeEvent.data.object as Stripe.PaymentIntent,
+        )
+        break
+
+      case 'payment_intent.payment_failed':
+        await this.stripeWebhooksService.handlePaymentIntentFailed(
+          stripeEvent.data.object as Stripe.PaymentIntent,
+        )
+        break
+
+      case 'charge.refunded':
+        await this.stripeWebhooksService.handleChargeRefunded(
+          stripeEvent.data.object as Stripe.Charge,
+        )
+        break
+
+      case 'charge.dispute.created':
+        this.stripeWebhooksService.handleChargeDisputeCreated(
+          stripeEvent.data.object as Stripe.Dispute,
+        )
+        break
+
+      default:
+        // Unhandled events are acknowledged but ignored — Stripe stops retrying on 200
+        break
+    }
   }
 }

--- a/apps/api/src/stripe/stripe-webhooks.service.spec.ts
+++ b/apps/api/src/stripe/stripe-webhooks.service.spec.ts
@@ -1,0 +1,175 @@
+import { Test, TestingModule } from '@nestjs/testing'
+import { OrderStatus, PaymentStatus } from '@prisma/client'
+import { Decimal } from '@prisma/client/runtime/library'
+import type Stripe from 'stripe'
+import { PrismaService } from '../prisma/prisma.service'
+import { StripeWebhooksService } from './stripe-webhooks.service'
+
+const ORDER_ID = 'order_test_123'
+const PAYMENT_ID = 'payment_test_abc'
+const STRIPE_INTENT_ID = 'pi_test_abc'
+const STRIPE_CHARGE_ID = 'ch_test_xyz'
+
+const buildMockPayment = (overrides: Record<string, unknown> = {}) => ({
+  id: PAYMENT_ID,
+  orderId: ORDER_ID,
+  stripeId: STRIPE_INTENT_ID,
+  status: PaymentStatus.PENDING,
+  amount: new Decimal('49.98'),
+  order: {
+    id: ORDER_ID,
+    status: OrderStatus.PENDING,
+  },
+  ...overrides,
+})
+
+const buildMockPaymentIntent = (overrides: Partial<Stripe.PaymentIntent> = {}) =>
+  ({ id: STRIPE_INTENT_ID, ...overrides }) as Stripe.PaymentIntent
+
+const buildMockCharge = (overrides: Partial<Stripe.Charge> = {}) =>
+  ({
+    id: STRIPE_CHARGE_ID,
+    payment_intent: STRIPE_INTENT_ID,
+    amount_refunded: 4998,
+    ...overrides,
+  }) as unknown as Stripe.Charge
+
+describe('StripeWebhooksService', () => {
+  let stripeWebhooksService: StripeWebhooksService
+  let mockPrismaService: {
+    payment: { findUnique: jest.Mock; update: jest.Mock }
+    order: { update: jest.Mock }
+    $transaction: jest.Mock
+  }
+
+  beforeEach(async () => {
+    mockPrismaService = {
+      payment: { findUnique: jest.fn(), update: jest.fn() },
+      order: { update: jest.fn() },
+      // Execute the callback directly so we can assert individual prisma calls
+      $transaction: jest.fn((callback) => callback(mockPrismaService)),
+    }
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [StripeWebhooksService, { provide: PrismaService, useValue: mockPrismaService }],
+    }).compile()
+
+    stripeWebhooksService = module.get<StripeWebhooksService>(StripeWebhooksService)
+  })
+
+  describe('handlePaymentIntentSucceeded', () => {
+    it('updates payment to SUCCEEDED and order to PAID', async () => {
+      mockPrismaService.payment.findUnique.mockResolvedValueOnce(buildMockPayment())
+
+      await stripeWebhooksService.handlePaymentIntentSucceeded(buildMockPaymentIntent())
+
+      expect(mockPrismaService.payment.update).toHaveBeenCalledWith(
+        expect.objectContaining({ data: { status: PaymentStatus.SUCCEEDED } }),
+      )
+      expect(mockPrismaService.order.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({ status: OrderStatus.PAID }),
+        }),
+      )
+    })
+
+    it('skips processing when payment is already SUCCEEDED (idempotency)', async () => {
+      mockPrismaService.payment.findUnique.mockResolvedValueOnce(
+        buildMockPayment({ status: PaymentStatus.SUCCEEDED }),
+      )
+
+      await stripeWebhooksService.handlePaymentIntentSucceeded(buildMockPaymentIntent())
+
+      expect(mockPrismaService.$transaction).not.toHaveBeenCalled()
+    })
+
+    it('skips when no payment record found for PaymentIntent', async () => {
+      mockPrismaService.payment.findUnique.mockResolvedValueOnce(null)
+
+      await stripeWebhooksService.handlePaymentIntentSucceeded(buildMockPaymentIntent())
+
+      expect(mockPrismaService.$transaction).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('handlePaymentIntentFailed', () => {
+    it('updates payment to FAILED and order to CANCELLED', async () => {
+      mockPrismaService.payment.findUnique.mockResolvedValueOnce(buildMockPayment())
+
+      await stripeWebhooksService.handlePaymentIntentFailed(buildMockPaymentIntent())
+
+      expect(mockPrismaService.payment.update).toHaveBeenCalledWith(
+        expect.objectContaining({ data: { status: PaymentStatus.FAILED } }),
+      )
+      expect(mockPrismaService.order.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            status: OrderStatus.CANCELLED,
+            cancelReason: 'PAYMENT_FAILED',
+          }),
+        }),
+      )
+    })
+
+    it('skips processing when payment is already FAILED (idempotency)', async () => {
+      mockPrismaService.payment.findUnique.mockResolvedValueOnce(
+        buildMockPayment({ status: PaymentStatus.FAILED }),
+      )
+
+      await stripeWebhooksService.handlePaymentIntentFailed(buildMockPaymentIntent())
+
+      expect(mockPrismaService.$transaction).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('handleChargeRefunded', () => {
+    it('updates payment to REFUNDED and order to REFUNDED with refund amount', async () => {
+      mockPrismaService.payment.findUnique.mockResolvedValueOnce(
+        buildMockPayment({ order: { id: ORDER_ID, status: OrderStatus.DELIVERED } }),
+      )
+
+      await stripeWebhooksService.handleChargeRefunded(buildMockCharge())
+
+      expect(mockPrismaService.payment.update).toHaveBeenCalledWith(
+        expect.objectContaining({ data: { status: PaymentStatus.REFUNDED } }),
+      )
+      expect(mockPrismaService.order.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            status: OrderStatus.REFUNDED,
+            // amount_refunded 4998 cents → $49.98
+            refundAmount: 49.98,
+          }),
+        }),
+      )
+    })
+
+    it('skips when charge has no payment_intent', async () => {
+      await stripeWebhooksService.handleChargeRefunded(buildMockCharge({ payment_intent: null }))
+
+      expect(mockPrismaService.payment.findUnique).not.toHaveBeenCalled()
+    })
+
+    it('skips processing when payment is already REFUNDED (idempotency)', async () => {
+      mockPrismaService.payment.findUnique.mockResolvedValueOnce(
+        buildMockPayment({ status: PaymentStatus.REFUNDED }),
+      )
+
+      await stripeWebhooksService.handleChargeRefunded(buildMockCharge())
+
+      expect(mockPrismaService.$transaction).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('handleChargeDisputeCreated', () => {
+    it('logs an error without throwing', () => {
+      const mockDispute = {
+        id: 'dp_test_123',
+        charge: STRIPE_CHARGE_ID,
+        amount: 4998,
+      } as Stripe.Dispute
+
+      expect(() => stripeWebhooksService.handleChargeDisputeCreated(mockDispute)).not.toThrow()
+    })
+  })
+})

--- a/apps/api/src/stripe/stripe-webhooks.service.ts
+++ b/apps/api/src/stripe/stripe-webhooks.service.ts
@@ -1,0 +1,167 @@
+import { Injectable, Logger } from '@nestjs/common'
+import { OrderStatus, PaymentStatus } from '@prisma/client'
+import type Stripe from 'stripe'
+import { PrismaService } from '../prisma/prisma.service'
+import { isValidOrderStatusTransition } from '../orders/order-status.transitions'
+
+@Injectable()
+export class StripeWebhooksService {
+  private readonly logger = new Logger(StripeWebhooksService.name)
+
+  constructor(private readonly prismaService: PrismaService) {}
+
+  async handlePaymentIntentSucceeded(paymentIntent: Stripe.PaymentIntent): Promise<void> {
+    const payment = await this.prismaService.payment.findUnique({
+      where: { stripeId: paymentIntent.id },
+      include: { order: true },
+    })
+
+    if (!payment) {
+      this.logger.warn(`Payment not found for PaymentIntent ${paymentIntent.id} — skipping`)
+      return
+    }
+
+    // Idempotency guard: skip if already processed
+    if (payment.status === PaymentStatus.SUCCEEDED) {
+      this.logger.log(`PaymentIntent ${paymentIntent.id} already processed — skipping`)
+      return
+    }
+
+    await this.prismaService.$transaction(async (transaction) => {
+      await transaction.payment.update({
+        where: { id: payment.id },
+        data: { status: PaymentStatus.SUCCEEDED },
+      })
+
+      if (isValidOrderStatusTransition(payment.order.status, OrderStatus.PAID)) {
+        await transaction.order.update({
+          where: { id: payment.orderId },
+          data: {
+            status: OrderStatus.PAID,
+            statusHistory: {
+              create: {
+                fromStatus: payment.order.status,
+                toStatus: OrderStatus.PAID,
+                note: `Stripe PaymentIntent ${paymentIntent.id} succeeded`,
+                createdBy: 'system',
+              },
+            },
+          },
+        })
+      } else {
+        this.logger.warn(
+          `Order ${payment.orderId} cannot transition from ${payment.order.status} to PAID — status history not updated`,
+        )
+      }
+    })
+
+    this.logger.log(`Order ${payment.orderId} transitioned to PAID`)
+  }
+
+  async handlePaymentIntentFailed(paymentIntent: Stripe.PaymentIntent): Promise<void> {
+    const payment = await this.prismaService.payment.findUnique({
+      where: { stripeId: paymentIntent.id },
+      include: { order: true },
+    })
+
+    if (!payment) {
+      this.logger.warn(`Payment not found for PaymentIntent ${paymentIntent.id} — skipping`)
+      return
+    }
+
+    if (payment.status === PaymentStatus.FAILED) {
+      this.logger.log(`PaymentIntent ${paymentIntent.id} already marked failed — skipping`)
+      return
+    }
+
+    await this.prismaService.$transaction(async (transaction) => {
+      await transaction.payment.update({
+        where: { id: payment.id },
+        data: { status: PaymentStatus.FAILED },
+      })
+
+      if (isValidOrderStatusTransition(payment.order.status, OrderStatus.CANCELLED)) {
+        await transaction.order.update({
+          where: { id: payment.orderId },
+          data: {
+            status: OrderStatus.CANCELLED,
+            cancelledAt: new Date(),
+            cancelReason: 'PAYMENT_FAILED',
+            statusHistory: {
+              create: {
+                fromStatus: payment.order.status,
+                toStatus: OrderStatus.CANCELLED,
+                note: `Stripe PaymentIntent ${paymentIntent.id} failed`,
+                createdBy: 'system',
+              },
+            },
+          },
+        })
+      }
+    })
+
+    this.logger.log(`Order ${payment.orderId} cancelled due to payment failure`)
+  }
+
+  async handleChargeRefunded(charge: Stripe.Charge): Promise<void> {
+    if (!charge.payment_intent) {
+      this.logger.warn(`Charge ${charge.id} has no payment_intent — skipping`)
+      return
+    }
+
+    const stripePaymentIntentId =
+      typeof charge.payment_intent === 'string' ? charge.payment_intent : charge.payment_intent.id
+
+    const payment = await this.prismaService.payment.findUnique({
+      where: { stripeId: stripePaymentIntentId },
+      include: { order: true },
+    })
+
+    if (!payment) {
+      this.logger.warn(`Payment not found for charge ${charge.id} — skipping`)
+      return
+    }
+
+    if (payment.status === PaymentStatus.REFUNDED) {
+      this.logger.log(`Charge ${charge.id} already refunded — skipping`)
+      return
+    }
+
+    const refundAmountInDollars = charge.amount_refunded / 100
+
+    await this.prismaService.$transaction(async (transaction) => {
+      await transaction.payment.update({
+        where: { id: payment.id },
+        data: { status: PaymentStatus.REFUNDED },
+      })
+
+      if (isValidOrderStatusTransition(payment.order.status, OrderStatus.REFUNDED)) {
+        await transaction.order.update({
+          where: { id: payment.orderId },
+          data: {
+            status: OrderStatus.REFUNDED,
+            refundedAt: new Date(),
+            refundAmount: refundAmountInDollars,
+            statusHistory: {
+              create: {
+                fromStatus: payment.order.status,
+                toStatus: OrderStatus.REFUNDED,
+                note: `Stripe charge ${charge.id} refunded — $${refundAmountInDollars}`,
+                createdBy: 'system',
+              },
+            },
+          },
+        })
+      }
+    })
+
+    this.logger.log(`Order ${payment.orderId} refunded — $${refundAmountInDollars}`)
+  }
+
+  handleChargeDisputeCreated(dispute: Stripe.Dispute): void {
+    // Post-MVP: send Slack/email alert and transition order to ON_HOLD
+    this.logger.error(
+      `DISPUTE CREATED — dispute ID: ${dispute.id}, charge: ${dispute.charge}, amount: $${dispute.amount / 100}`,
+    )
+  }
+}

--- a/apps/api/src/stripe/stripe.module.ts
+++ b/apps/api/src/stripe/stripe.module.ts
@@ -1,10 +1,11 @@
 import { Module } from '@nestjs/common'
 import { StripeService } from './stripe.service'
 import { StripeWebhooksController } from './stripe-webhooks.controller'
+import { StripeWebhooksService } from './stripe-webhooks.service'
 
 @Module({
   controllers: [StripeWebhooksController],
-  providers: [StripeService],
+  providers: [StripeService, StripeWebhooksService],
   exports: [StripeService],
 })
 export class StripeModule {}

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -10,4 +10,4 @@ NEXT_PUBLIC_API_URL=http://localhost:4000
 # Публичный ключ (безопасно передавать в браузер — NEXT_PUBLIC_)
 # Тестовый: Stripe Dashboard → Test mode → Developers → API keys → Publishable key (pk_test_...)
 # Production: то же самое, но в Live mode (pk_live_...)
-NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=
+NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=pk_test_your_stripe_publishable_key_here

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -172,5 +172,30 @@
     "payNow": "Pay {amount}",
     "paymentLoading": "Preparing payment form…",
     "initiateCheckoutError": "Could not initialize payment. Please go back and try again."
+  },
+  "confirmationPage": {
+    "metaTitle": "Order Confirmed",
+    "metaDescription": "Your order has been placed successfully.",
+    "title": "Thank you for your order!",
+    "subtitle": "Your payment was successful and your order is confirmed.",
+    "emailNote": "A confirmation email is on its way to you.",
+    "orderIdLabel": "Order",
+    "nextStepsTitle": "What happens next",
+    "step1Title": "Order Confirmed",
+    "step1Description": "We've received your order and payment.",
+    "step2Title": "Being Handcrafted",
+    "step2Description": "Your piece is being carefully made by hand.",
+    "step3Title": "Quality Check",
+    "step3Description": "Each item is inspected before packing.",
+    "step4Title": "On Its Way",
+    "step4Description": "Shipped with love and tracking details by email.",
+    "orderSummaryTitle": "Order Summary",
+    "subtotal": "Subtotal",
+    "shipping": "Shipping",
+    "shippingFree": "FREE",
+    "total": "Total",
+    "shippingAddressTitle": "Shipping To",
+    "itemQuantity": "Qty: {quantity}",
+    "continueShopping": "Continue Shopping"
   }
 }

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -172,5 +172,30 @@
     "payNow": "Pagar {amount}",
     "paymentLoading": "Preparando el formulario de pago…",
     "initiateCheckoutError": "No se pudo inicializar el pago. Vuelve atrás e inténtalo de nuevo."
+  },
+  "confirmationPage": {
+    "metaTitle": "Pedido confirmado",
+    "metaDescription": "Tu pedido se ha realizado correctamente.",
+    "title": "¡Gracias por tu compra!",
+    "subtitle": "El pago se realizó con éxito y tu pedido está confirmado.",
+    "emailNote": "Te hemos enviado un correo de confirmación.",
+    "orderIdLabel": "Pedido",
+    "nextStepsTitle": "¿Qué pasa ahora?",
+    "step1Title": "Pedido confirmado",
+    "step1Description": "Hemos recibido tu pedido y el pago.",
+    "step2Title": "Elaboración artesanal",
+    "step2Description": "Tu pieza está siendo hecha a mano con cuidado.",
+    "step3Title": "Control de calidad",
+    "step3Description": "Cada artículo se inspecciona antes de empaquetar.",
+    "step4Title": "En camino",
+    "step4Description": "Enviado con amor y número de seguimiento por correo.",
+    "orderSummaryTitle": "Resumen del pedido",
+    "subtotal": "Subtotal",
+    "shipping": "Envío",
+    "shippingFree": "GRATIS",
+    "total": "Total",
+    "shippingAddressTitle": "Dirección de envío",
+    "itemQuantity": "Cant.: {quantity}",
+    "continueShopping": "Seguir comprando"
   }
 }

--- a/apps/web/messages/ru.json
+++ b/apps/web/messages/ru.json
@@ -172,5 +172,30 @@
     "payNow": "Оплатить {amount}",
     "paymentLoading": "Подготовка формы оплаты…",
     "initiateCheckoutError": "Не удалось инициализировать оплату. Вернитесь и попробуйте снова."
+  },
+  "confirmationPage": {
+    "metaTitle": "Заказ подтверждён",
+    "metaDescription": "Ваш заказ успешно оформлен.",
+    "title": "Спасибо за покупку!",
+    "subtitle": "Оплата прошла успешно, ваш заказ подтверждён.",
+    "emailNote": "Письмо с подтверждением уже летит к вам.",
+    "orderIdLabel": "Заказ",
+    "nextStepsTitle": "Что будет дальше",
+    "step1Title": "Заказ подтверждён",
+    "step1Description": "Мы получили ваш заказ и оплату.",
+    "step2Title": "Изготовление вручную",
+    "step2Description": "Ваше украшение аккуратно создаётся вручную.",
+    "step3Title": "Контроль качества",
+    "step3Description": "Каждое изделие проверяется перед упаковкой.",
+    "step4Title": "В пути",
+    "step4Description": "Отправлено с любовью, трекинг придёт на email.",
+    "orderSummaryTitle": "Состав заказа",
+    "subtotal": "Подитог",
+    "shipping": "Доставка",
+    "shippingFree": "БЕСПЛАТНО",
+    "total": "Итого",
+    "shippingAddressTitle": "Адрес доставки",
+    "itemQuantity": "Кол-во: {quantity}",
+    "continueShopping": "Продолжить покупки"
   }
 }

--- a/apps/web/src/app/[locale]/checkout/_components/__tests__/checkout-payment-form.test.tsx
+++ b/apps/web/src/app/[locale]/checkout/_components/__tests__/checkout-payment-form.test.tsx
@@ -5,6 +5,7 @@ import type { CheckoutAddressFormValues } from '../checkout-address-schema'
 
 vi.mock('next-intl', () => ({
   useTranslations: () => (key: string) => key,
+  useLocale: () => 'en',
 }))
 
 vi.mock('../checkout-order-summary', () => ({

--- a/apps/web/src/app/[locale]/checkout/_components/checkout-payment-form.tsx
+++ b/apps/web/src/app/[locale]/checkout/_components/checkout-payment-form.tsx
@@ -3,7 +3,7 @@
 import { useState } from 'react'
 import { loadStripe } from '@stripe/stripe-js'
 import { Elements } from '@stripe/react-stripe-js'
-import { useTranslations } from 'next-intl'
+import { useLocale, useTranslations } from 'next-intl'
 import { useCartTotalPrice } from '@/store/cart.store'
 import { CheckoutOrderSummary } from './checkout-order-summary'
 import { CheckoutSteps } from './checkout-steps'
@@ -29,6 +29,7 @@ export function CheckoutPaymentForm({
   onBack,
 }: CheckoutPaymentFormProps) {
   const t = useTranslations('checkoutPage')
+  const locale = useLocale()
   const cartTotalPrice = useCartTotalPrice()
   const totalInCents = Math.round((cartTotalPrice + shippingCost) * 100)
 
@@ -41,7 +42,7 @@ export function CheckoutPaymentForm({
 
   const returnUrl =
     typeof window !== 'undefined' && orderId
-      ? `${window.location.origin}/checkout/confirmation/${orderId}`
+      ? `${window.location.origin}/${locale}/checkout/confirmation/${orderId}`
       : ''
 
   return (

--- a/apps/web/src/app/[locale]/checkout/_components/hooks/use-submit-checkout-order.ts
+++ b/apps/web/src/app/[locale]/checkout/_components/hooks/use-submit-checkout-order.ts
@@ -1,7 +1,7 @@
 'use client'
 
 import { useMutation } from '@tanstack/react-query'
-import { useRouter } from 'next/navigation'
+import { useRouter } from '@/i18n/navigation'
 import { createOrder } from '@/lib/api/orders'
 import { useCartItems } from '@/store/cart.store'
 import { buildOrderPayload } from '../../_lib/build-order-payload'

--- a/apps/web/src/app/[locale]/checkout/confirmation/[orderId]/_components/__tests__/confirmation-next-steps.test.tsx
+++ b/apps/web/src/app/[locale]/checkout/confirmation/[orderId]/_components/__tests__/confirmation-next-steps.test.tsx
@@ -1,0 +1,32 @@
+import { render, screen } from '@testing-library/react'
+import { NextIntlClientProvider } from 'next-intl'
+import messages from '../../../../../../../../messages/en.json'
+import { ConfirmationNextSteps } from '../confirmation-next-steps'
+
+function renderWithIntl(component: React.ReactNode) {
+  return render(
+    <NextIntlClientProvider locale="en" messages={messages}>
+      {component}
+    </NextIntlClientProvider>,
+  )
+}
+
+describe('ConfirmationNextSteps', () => {
+  it('renders the section heading', () => {
+    renderWithIntl(<ConfirmationNextSteps />)
+    expect(screen.getByRole('heading', { level: 2 })).toHaveTextContent('What happens next')
+  })
+
+  it('renders all 4 steps', () => {
+    renderWithIntl(<ConfirmationNextSteps />)
+    expect(screen.getByText('Order Confirmed')).toBeInTheDocument()
+    expect(screen.getByText('Being Handcrafted')).toBeInTheDocument()
+    expect(screen.getByText('Quality Check')).toBeInTheDocument()
+    expect(screen.getByText('On Its Way')).toBeInTheDocument()
+  })
+
+  it('renders the handcrafting step description', () => {
+    renderWithIntl(<ConfirmationNextSteps />)
+    expect(screen.getByText(/carefully made by hand/i)).toBeInTheDocument()
+  })
+})

--- a/apps/web/src/app/[locale]/checkout/confirmation/[orderId]/_components/__tests__/confirmation-order-items.test.tsx
+++ b/apps/web/src/app/[locale]/checkout/confirmation/[orderId]/_components/__tests__/confirmation-order-items.test.tsx
@@ -1,0 +1,73 @@
+import { render, screen } from '@testing-library/react'
+import { NextIntlClientProvider } from 'next-intl'
+import messages from '../../../../../../../../messages/en.json'
+import type { OrderItem } from '@/lib/api/orders'
+import { ConfirmationOrderItems } from '../confirmation-order-items'
+
+const mockOrderItems: OrderItem[] = [
+  {
+    id: 'item_1',
+    productId: 'prod_1',
+    quantity: 2,
+    price: 24.99,
+    productSnapshot: {
+      title: 'Beaded Amazonite Bracelet',
+      slug: 'beaded-amazonite-bracelet',
+      image: undefined,
+    },
+  },
+  {
+    id: 'item_2',
+    productId: 'prod_2',
+    quantity: 1,
+    price: 49.99,
+    productSnapshot: {
+      title: 'Sterling Silver Ring',
+      slug: 'sterling-silver-ring',
+      image: 'https://example.com/ring.jpg',
+    },
+  },
+]
+
+function renderWithIntl(component: React.ReactNode) {
+  return render(
+    <NextIntlClientProvider locale="en" messages={messages}>
+      {component}
+    </NextIntlClientProvider>,
+  )
+}
+
+describe('ConfirmationOrderItems', () => {
+  it('renders all order items', () => {
+    renderWithIntl(<ConfirmationOrderItems items={mockOrderItems} />)
+    expect(screen.getByText('Beaded Amazonite Bracelet')).toBeInTheDocument()
+    expect(screen.getByText('Sterling Silver Ring')).toBeInTheDocument()
+  })
+
+  it('shows item quantity', () => {
+    renderWithIntl(<ConfirmationOrderItems items={mockOrderItems} />)
+    expect(screen.getByText('Qty: 2')).toBeInTheDocument()
+    expect(screen.getByText('Qty: 1')).toBeInTheDocument()
+  })
+
+  it('shows line total (price × quantity)', () => {
+    renderWithIntl(<ConfirmationOrderItems items={mockOrderItems} />)
+    // item_1: 24.99 × 2 = $49.98
+    expect(screen.getByText('$49.98')).toBeInTheDocument()
+    // item_2: 49.99 × 1 = $49.99
+    expect(screen.getByText('$49.99')).toBeInTheDocument()
+  })
+
+  it('renders a product image when the snapshot has one', () => {
+    renderWithIntl(<ConfirmationOrderItems items={mockOrderItems} />)
+    const image = screen.getByAltText('Sterling Silver Ring')
+    expect(image).toBeInTheDocument()
+  })
+
+  it('renders a placeholder when the snapshot has no image', () => {
+    renderWithIntl(<ConfirmationOrderItems items={[mockOrderItems[0]]} />)
+    expect(screen.queryByAltText('Beaded Amazonite Bracelet')).not.toBeInTheDocument()
+    // placeholder decorative symbol is rendered
+    expect(screen.getByText('✦')).toBeInTheDocument()
+  })
+})

--- a/apps/web/src/app/[locale]/checkout/confirmation/[orderId]/_components/__tests__/confirmation-order-summary.test.tsx
+++ b/apps/web/src/app/[locale]/checkout/confirmation/[orderId]/_components/__tests__/confirmation-order-summary.test.tsx
@@ -1,0 +1,71 @@
+import { render, screen } from '@testing-library/react'
+import { NextIntlClientProvider } from 'next-intl'
+import messages from '../../../../../../../../messages/en.json'
+import type { OrderDetails } from '@/lib/api/orders'
+import { ConfirmationOrderSummary } from '../confirmation-order-summary'
+
+const mockOrder: OrderDetails = {
+  id: 'order_123',
+  status: 'PAID',
+  subtotal: 49.98,
+  shippingCost: 5.0,
+  total: 54.98,
+  guestEmail: 'test@example.com',
+  createdAt: '2026-01-01T00:00:00.000Z',
+  items: [],
+  shippingAddress: {
+    fullName: 'Jane Smith',
+    addressLine1: '123 Main St',
+    addressLine2: 'Apt 4B',
+    city: 'New York',
+    state: 'NY',
+    postalCode: '10001',
+    country: 'US',
+  },
+}
+
+function renderWithIntl(component: React.ReactNode) {
+  return render(
+    <NextIntlClientProvider locale="en" messages={messages}>
+      {component}
+    </NextIntlClientProvider>,
+  )
+}
+
+describe('ConfirmationOrderSummary', () => {
+  it('displays shipping address details', () => {
+    renderWithIntl(<ConfirmationOrderSummary order={mockOrder} />)
+    expect(screen.getByText('Jane Smith')).toBeInTheDocument()
+    expect(screen.getByText('123 Main St')).toBeInTheDocument()
+    expect(screen.getByText('Apt 4B')).toBeInTheDocument()
+    expect(screen.getByText('New York, NY 10001')).toBeInTheDocument()
+    expect(screen.getByText('US')).toBeInTheDocument()
+  })
+
+  it('displays order totals', () => {
+    renderWithIntl(<ConfirmationOrderSummary order={mockOrder} />)
+    expect(screen.getByText('$49.98')).toBeInTheDocument()
+    expect(screen.getByText('$5.00')).toBeInTheDocument()
+    expect(screen.getByText('$54.98')).toBeInTheDocument()
+  })
+
+  it('shows FREE label when shipping cost is zero', () => {
+    const freeShippingOrder = { ...mockOrder, shippingCost: 0, total: 49.98 }
+    renderWithIntl(<ConfirmationOrderSummary order={freeShippingOrder} />)
+    expect(screen.getByText('FREE')).toBeInTheDocument()
+  })
+
+  it('displays the optional addressLine2 when present', () => {
+    renderWithIntl(<ConfirmationOrderSummary order={mockOrder} />)
+    expect(screen.getByText('Apt 4B')).toBeInTheDocument()
+  })
+
+  it('omits addressLine2 when not provided', () => {
+    const orderWithoutLine2 = {
+      ...mockOrder,
+      shippingAddress: { ...mockOrder.shippingAddress, addressLine2: undefined },
+    }
+    renderWithIntl(<ConfirmationOrderSummary order={orderWithoutLine2} />)
+    expect(screen.queryByText('Apt 4B')).not.toBeInTheDocument()
+  })
+})

--- a/apps/web/src/app/[locale]/checkout/confirmation/[orderId]/_components/__tests__/confirmation-success-header.test.tsx
+++ b/apps/web/src/app/[locale]/checkout/confirmation/[orderId]/_components/__tests__/confirmation-success-header.test.tsx
@@ -1,0 +1,31 @@
+import { render, screen } from '@testing-library/react'
+import { NextIntlClientProvider } from 'next-intl'
+import messages from '../../../../../../../../messages/en.json'
+import { ConfirmationSuccessHeader } from '../confirmation-success-header'
+
+const ORDER_ID = 'cmn9h19k8000i1djemmcs10tz'
+
+function renderWithIntl(component: React.ReactNode) {
+  return render(
+    <NextIntlClientProvider locale="en" messages={messages}>
+      {component}
+    </NextIntlClientProvider>,
+  )
+}
+
+describe('ConfirmationSuccessHeader', () => {
+  it('displays the order title', () => {
+    renderWithIntl(<ConfirmationSuccessHeader orderId={ORDER_ID} />)
+    expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent('Thank you for your order!')
+  })
+
+  it('displays the order ID', () => {
+    renderWithIntl(<ConfirmationSuccessHeader orderId={ORDER_ID} />)
+    expect(screen.getByText(ORDER_ID)).toBeInTheDocument()
+  })
+
+  it('displays the email confirmation note', () => {
+    renderWithIntl(<ConfirmationSuccessHeader orderId={ORDER_ID} />)
+    expect(screen.getByText(/confirmation email/i)).toBeInTheDocument()
+  })
+})

--- a/apps/web/src/app/[locale]/checkout/confirmation/[orderId]/_components/confirmation-next-steps.tsx
+++ b/apps/web/src/app/[locale]/checkout/confirmation/[orderId]/_components/confirmation-next-steps.tsx
@@ -1,0 +1,47 @@
+import { CheckCircle2, Hammer, Package, Truck } from 'lucide-react'
+import { useTranslations } from 'next-intl'
+
+const NEXT_STEPS = [
+  { icon: CheckCircle2, titleKey: 'step1Title', descriptionKey: 'step1Description', done: true },
+  { icon: Hammer, titleKey: 'step2Title', descriptionKey: 'step2Description', done: false },
+  { icon: Package, titleKey: 'step3Title', descriptionKey: 'step3Description', done: false },
+  { icon: Truck, titleKey: 'step4Title', descriptionKey: 'step4Description', done: false },
+] as const
+
+export function ConfirmationNextSteps() {
+  const t = useTranslations('confirmationPage')
+
+  return (
+    <section aria-labelledby="next-steps-heading">
+      <h2 id="next-steps-heading" className="mb-4 text-base font-semibold text-foreground">
+        {t('nextStepsTitle')}
+      </h2>
+
+      <ol className="relative border-l border-border">
+        {NEXT_STEPS.map((step, index) => {
+          const StepIcon = step.icon
+          return (
+            <li key={step.titleKey} className="mb-6 ml-6 last:mb-0">
+              <span
+                className={[
+                  'absolute -left-3 flex h-6 w-6 items-center justify-center rounded-full ring-4 ring-background',
+                  step.done ? 'bg-green-500 text-white' : 'bg-muted text-muted-foreground',
+                ].join(' ')}
+                aria-hidden="true"
+              >
+                <StepIcon className="h-3.5 w-3.5" />
+              </span>
+
+              <div
+                className={index === 1 ? 'opacity-100' : step.done ? 'opacity-100' : 'opacity-50'}
+              >
+                <p className="text-sm font-medium text-foreground">{t(step.titleKey)}</p>
+                <p className="text-sm text-muted-foreground">{t(step.descriptionKey)}</p>
+              </div>
+            </li>
+          )
+        })}
+      </ol>
+    </section>
+  )
+}

--- a/apps/web/src/app/[locale]/checkout/confirmation/[orderId]/_components/confirmation-order-items.tsx
+++ b/apps/web/src/app/[locale]/checkout/confirmation/[orderId]/_components/confirmation-order-items.tsx
@@ -1,0 +1,50 @@
+import Image from 'next/image'
+import { useTranslations } from 'next-intl'
+import type { OrderItem } from '@/lib/api/orders'
+
+interface ConfirmationOrderItemsProps {
+  items: OrderItem[]
+}
+
+export function ConfirmationOrderItems({ items }: ConfirmationOrderItemsProps) {
+  const t = useTranslations('confirmationPage')
+
+  return (
+    <ul role="list" className="divide-y divide-border">
+      {items.map((orderItem) => (
+        <li key={orderItem.id} className="flex gap-4 py-4 first:pt-0 last:pb-0">
+          <div className="relative h-16 w-16 shrink-0 overflow-hidden rounded-md border border-border bg-muted">
+            {orderItem.productSnapshot.image ? (
+              <Image
+                src={orderItem.productSnapshot.image}
+                alt={orderItem.productSnapshot.title}
+                fill
+                className="object-cover"
+                sizes="64px"
+              />
+            ) : (
+              <div className="flex h-full w-full items-center justify-center text-xs text-muted-foreground">
+                ✦
+              </div>
+            )}
+          </div>
+
+          <div className="flex flex-1 flex-col justify-center gap-0.5">
+            <p className="text-sm font-medium text-foreground leading-snug">
+              {orderItem.productSnapshot.title}
+            </p>
+            <p className="text-xs text-muted-foreground">
+              {t('itemQuantity', { quantity: orderItem.quantity })}
+            </p>
+          </div>
+
+          <p className="text-sm font-medium text-foreground tabular-nums">
+            {new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' }).format(
+              orderItem.price * orderItem.quantity,
+            )}
+          </p>
+        </li>
+      ))}
+    </ul>
+  )
+}

--- a/apps/web/src/app/[locale]/checkout/confirmation/[orderId]/_components/confirmation-order-summary.tsx
+++ b/apps/web/src/app/[locale]/checkout/confirmation/[orderId]/_components/confirmation-order-summary.tsx
@@ -1,0 +1,69 @@
+import { useTranslations } from 'next-intl'
+import type { OrderDetails } from '@/lib/api/orders'
+
+interface ConfirmationOrderSummaryProps {
+  order: OrderDetails
+}
+
+function formatUsd(amount: number): string {
+  return new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' }).format(amount)
+}
+
+export function ConfirmationOrderSummary({ order }: ConfirmationOrderSummaryProps) {
+  const t = useTranslations('confirmationPage')
+  const { shippingAddress } = order
+
+  return (
+    <div className="grid gap-6 sm:grid-cols-2">
+      {/* Shipping address */}
+      <section aria-labelledby="shipping-address-heading">
+        <h2
+          id="shipping-address-heading"
+          className="mb-3 text-sm font-semibold uppercase tracking-wider text-muted-foreground"
+        >
+          {t('shippingAddressTitle')}
+        </h2>
+        <address className="not-italic text-sm text-foreground leading-relaxed">
+          <p className="font-medium">{shippingAddress.fullName}</p>
+          <p>{shippingAddress.addressLine1}</p>
+          {shippingAddress.addressLine2 && <p>{shippingAddress.addressLine2}</p>}
+          <p>
+            {shippingAddress.city}
+            {shippingAddress.state ? `, ${shippingAddress.state}` : ''} {shippingAddress.postalCode}
+          </p>
+          <p>{shippingAddress.country}</p>
+        </address>
+      </section>
+
+      {/* Order totals */}
+      <section aria-labelledby="order-totals-heading">
+        <h2
+          id="order-totals-heading"
+          className="mb-3 text-sm font-semibold uppercase tracking-wider text-muted-foreground"
+        >
+          {t('orderSummaryTitle')}
+        </h2>
+        <dl className="space-y-1.5 text-sm">
+          <div className="flex justify-between">
+            <dt className="text-muted-foreground">{t('subtotal')}</dt>
+            <dd className="tabular-nums">{formatUsd(order.subtotal)}</dd>
+          </div>
+          <div className="flex justify-between">
+            <dt className="text-muted-foreground">{t('shipping')}</dt>
+            <dd className="tabular-nums">
+              {order.shippingCost === 0 ? (
+                <span className="text-green-600 dark:text-green-400">{t('shippingFree')}</span>
+              ) : (
+                formatUsd(order.shippingCost)
+              )}
+            </dd>
+          </div>
+          <div className="flex justify-between border-t border-border pt-2 font-semibold">
+            <dt>{t('total')}</dt>
+            <dd className="tabular-nums">{formatUsd(order.total)}</dd>
+          </div>
+        </dl>
+      </section>
+    </div>
+  )
+}

--- a/apps/web/src/app/[locale]/checkout/confirmation/[orderId]/_components/confirmation-success-header.tsx
+++ b/apps/web/src/app/[locale]/checkout/confirmation/[orderId]/_components/confirmation-success-header.tsx
@@ -1,0 +1,35 @@
+import { CheckCircle, Mail } from 'lucide-react'
+import { useTranslations } from 'next-intl'
+
+interface ConfirmationSuccessHeaderProps {
+  orderId: string
+}
+
+export function ConfirmationSuccessHeader({ orderId }: ConfirmationSuccessHeaderProps) {
+  const t = useTranslations('confirmationPage')
+
+  return (
+    <div className="flex flex-col items-center gap-4 text-center">
+      <div className="flex h-20 w-20 items-center justify-center rounded-full bg-green-500/10">
+        <CheckCircle className="h-10 w-10 text-green-500" aria-hidden="true" />
+      </div>
+
+      <div className="space-y-1">
+        <h1 className="text-2xl font-semibold text-foreground sm:text-3xl">{t('title')}</h1>
+        <p className="text-muted-foreground">{t('subtitle')}</p>
+      </div>
+
+      <div className="flex items-center gap-2 rounded-full border border-border bg-muted/50 px-4 py-2">
+        <Mail className="h-4 w-4 shrink-0 text-muted-foreground" aria-hidden="true" />
+        <p className="text-sm text-muted-foreground">{t('emailNote')}</p>
+      </div>
+
+      <div className="rounded-lg border border-border bg-card px-5 py-3 text-left">
+        <span className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
+          {t('orderIdLabel')}
+        </span>
+        <p className="mt-0.5 font-mono text-sm font-medium text-foreground">{orderId}</p>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/app/[locale]/checkout/confirmation/[orderId]/page.tsx
+++ b/apps/web/src/app/[locale]/checkout/confirmation/[orderId]/page.tsx
@@ -1,0 +1,66 @@
+import type { Metadata } from 'next'
+import { getTranslations } from 'next-intl/server'
+import Link from 'next/link'
+import { notFound } from 'next/navigation'
+import { Button } from '@/components/ui/button'
+import { Separator } from '@/components/ui/separator'
+import { fetchOrderById } from '@/lib/api/orders'
+import { ConfirmationNextSteps } from './_components/confirmation-next-steps'
+import { ConfirmationOrderItems } from './_components/confirmation-order-items'
+import { ConfirmationOrderSummary } from './_components/confirmation-order-summary'
+import { ConfirmationSuccessHeader } from './_components/confirmation-success-header'
+
+interface ConfirmationPageProps {
+  params: Promise<{ locale: string; orderId: string }>
+}
+
+export async function generateMetadata({ params }: ConfirmationPageProps): Promise<Metadata> {
+  const { locale } = await params
+  const t = await getTranslations({ locale, namespace: 'confirmationPage' })
+
+  return {
+    title: t('metaTitle'),
+    description: t('metaDescription'),
+  }
+}
+
+export default async function ConfirmationPage({ params }: ConfirmationPageProps) {
+  const { orderId } = await params
+
+  let order
+  try {
+    order = await fetchOrderById(orderId)
+  } catch {
+    notFound()
+  }
+
+  const t = await getTranslations('confirmationPage')
+
+  return (
+    <main className="mx-auto max-w-2xl px-4 py-12 sm:px-6">
+      <div className="space-y-8">
+        <ConfirmationSuccessHeader orderId={order.id} />
+
+        <Separator />
+
+        <ConfirmationNextSteps />
+
+        <Separator />
+
+        <section aria-label={t('orderSummaryTitle')}>
+          <ConfirmationOrderItems items={order.items} />
+        </section>
+
+        <Separator />
+
+        <ConfirmationOrderSummary order={order} />
+
+        <div className="flex justify-center pt-2">
+          <Button asChild size="lg">
+            <Link href="/shop">{t('continueShopping')}</Link>
+          </Button>
+        </div>
+      </div>
+    </main>
+  )
+}

--- a/apps/web/src/lib/api/client.ts
+++ b/apps/web/src/lib/api/client.ts
@@ -30,7 +30,20 @@ export async function apiClient<T>(path: string, options?: RequestInit): Promise
   })
 
   if (!response.ok) {
-    throw new ApiError(response.status, `API ${response.status}: ${response.statusText} — ${path}`)
+    // Attempt to extract NestJS error message from response body
+    let errorMessage = `${response.status}: ${response.statusText} — ${path}`
+    try {
+      const errorBody = (await response.json()) as { message?: string | string[] }
+      if (errorBody.message) {
+        const bodyMessage = Array.isArray(errorBody.message)
+          ? errorBody.message.join(', ')
+          : errorBody.message
+        errorMessage = `${response.status}: ${bodyMessage}`
+      }
+    } catch {
+      // response body is not JSON — keep default message
+    }
+    throw new ApiError(response.status, `API ${errorMessage}`)
   }
 
   return response.json() as Promise<T>

--- a/apps/web/src/lib/api/orders.ts
+++ b/apps/web/src/lib/api/orders.ts
@@ -40,6 +40,35 @@ export interface CreatedOrder {
   total: number
 }
 
+export interface OrderItem {
+  id: string
+  productId: string
+  quantity: number
+  price: number
+  productSnapshot: {
+    title: string
+    slug: string
+    sku?: string
+    image?: string
+  }
+}
+
+export interface OrderDetails {
+  id: string
+  status: string
+  subtotal: number
+  shippingCost: number
+  total: number
+  guestEmail: string | null
+  shippingAddress: ShippingAddress
+  items: OrderItem[]
+  createdAt: string
+}
+
+export async function fetchOrderById(orderId: string): Promise<OrderDetails> {
+  return apiClient<OrderDetails>(`/api/orders/${orderId}`)
+}
+
 export async function createOrder(payload: CreateOrderPayload): Promise<CreatedOrder> {
   return apiClient<CreatedOrder>('/api/orders', {
     method: 'POST',


### PR DESCRIPTION
feat: add order confirmation page with handmade timeline and order details #115

## Why

<!-- What problem does this PR solve? Link to the issue. -->

Closes #

## What changed

<!-- List the key changes. Be specific. -->

-

## How to test

<!-- Steps to verify the change works correctly. -->

1.

## Checklist

- [ ] No `any` types in TypeScript
- [ ] `pnpm lint` passes
- [ ] `pnpm build` passes locally
- [ ] Self-reviewed the diff before opening PR
