### PR TITLE
feat: payment success and failure pages — handle Stripe redirect_stat…

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -202,7 +202,15 @@
     "total": "Total",
     "shippingAddressTitle": "Shipping To",
     "itemQuantity": "Qty: {quantity}",
-    "continueShopping": "Continue Shopping"
+    "continueShopping": "Continue Shopping",
+    "paymentFailedMetaTitle": "Payment Failed",
+    "paymentFailedMetaDescription": "Your payment could not be processed. Please try again.",
+    "paymentFailedTitle": "Payment failed",
+    "paymentFailedSubtitle": "We couldn't process your payment. Your card was not charged.",
+    "paymentFailedTryAgain": "Try Again",
+    "paymentFailedBackToCart": "Back to Cart",
+    "paymentCancelledTitle": "Payment cancelled",
+    "paymentCancelledSubtitle": "You cancelled the payment. Your cart is still saved."
   },
   "auth": {
     "registerMetaTitle": "Create Account",

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -202,7 +202,15 @@
     "total": "Total",
     "shippingAddressTitle": "Dirección de envío",
     "itemQuantity": "Cant.: {quantity}",
-    "continueShopping": "Seguir comprando"
+    "continueShopping": "Seguir comprando",
+    "paymentFailedMetaTitle": "Pago fallido",
+    "paymentFailedMetaDescription": "No se pudo procesar el pago. Por favor, inténtalo de nuevo.",
+    "paymentFailedTitle": "Pago fallido",
+    "paymentFailedSubtitle": "No pudimos procesar tu pago. No se realizó ningún cargo a tu tarjeta.",
+    "paymentFailedTryAgain": "Intentar de nuevo",
+    "paymentFailedBackToCart": "Volver al carrito",
+    "paymentCancelledTitle": "Pago cancelado",
+    "paymentCancelledSubtitle": "Has cancelado el pago. Tu carrito sigue guardado."
   },
   "auth": {
     "registerMetaTitle": "Crear cuenta",

--- a/apps/web/messages/ru.json
+++ b/apps/web/messages/ru.json
@@ -202,7 +202,15 @@
     "total": "Итого",
     "shippingAddressTitle": "Адрес доставки",
     "itemQuantity": "Кол-во: {quantity}",
-    "continueShopping": "Продолжить покупки"
+    "continueShopping": "Продолжить покупки",
+    "paymentFailedMetaTitle": "Ошибка оплаты",
+    "paymentFailedMetaDescription": "Оплата не прошла. Пожалуйста, попробуйте снова.",
+    "paymentFailedTitle": "Оплата не прошла",
+    "paymentFailedSubtitle": "Не удалось обработать платёж. Карта не была списана.",
+    "paymentFailedTryAgain": "Попробовать снова",
+    "paymentFailedBackToCart": "Вернуться в корзину",
+    "paymentCancelledTitle": "Оплата отменена",
+    "paymentCancelledSubtitle": "Вы отменили оплату. Корзина сохранена."
   },
   "auth": {
     "registerMetaTitle": "Создать аккаунт",

--- a/apps/web/src/app/[locale]/checkout/confirmation/[orderId]/_components/__tests__/payment-failed-content.test.tsx
+++ b/apps/web/src/app/[locale]/checkout/confirmation/[orderId]/_components/__tests__/payment-failed-content.test.tsx
@@ -1,0 +1,70 @@
+import { render, screen } from '@testing-library/react'
+import { NextIntlClientProvider } from 'next-intl'
+import messages from '../../../../../../../../messages/en.json'
+import { PaymentFailedContent } from '../payment-failed-content'
+
+const ORDER_ID = 'cmn9h19k8000i1djemmcs10tz'
+
+function renderWithIntl(component: React.ReactNode) {
+  return render(
+    <NextIntlClientProvider locale="en" messages={messages}>
+      {component}
+    </NextIntlClientProvider>,
+  )
+}
+
+describe('PaymentFailedContent — payment failed', () => {
+  it('displays the payment failed heading', () => {
+    renderWithIntl(<PaymentFailedContent orderId={ORDER_ID} wasCancelled={false} />)
+
+    expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent('Payment failed')
+  })
+
+  it('displays the "card was not charged" subtitle', () => {
+    renderWithIntl(<PaymentFailedContent orderId={ORDER_ID} wasCancelled={false} />)
+
+    expect(screen.getByText(/not charged/i)).toBeInTheDocument()
+  })
+
+  it('renders a "Try Again" link pointing to /checkout', () => {
+    renderWithIntl(<PaymentFailedContent orderId={ORDER_ID} wasCancelled={false} />)
+
+    const tryAgainLink = screen.getByRole('link', { name: /try again/i })
+    expect(tryAgainLink).toBeInTheDocument()
+    expect(tryAgainLink).toHaveAttribute('href', '/checkout')
+  })
+
+  it('renders a "Back to Cart" link', () => {
+    renderWithIntl(<PaymentFailedContent orderId={ORDER_ID} wasCancelled={false} />)
+
+    const backToCartLink = screen.getByRole('link', { name: /back to cart/i })
+    expect(backToCartLink).toBeInTheDocument()
+    expect(backToCartLink).toHaveAttribute('href', '/cart')
+  })
+})
+
+describe('PaymentFailedContent — payment cancelled', () => {
+  it('displays the payment cancelled heading', () => {
+    renderWithIntl(<PaymentFailedContent orderId={ORDER_ID} wasCancelled={true} />)
+
+    expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent('Payment cancelled')
+  })
+
+  it('displays the "cart is still saved" subtitle', () => {
+    renderWithIntl(<PaymentFailedContent orderId={ORDER_ID} wasCancelled={true} />)
+
+    expect(screen.getByText(/cart is still saved/i)).toBeInTheDocument()
+  })
+
+  it('does not render the "Try Again" button when payment was cancelled', () => {
+    renderWithIntl(<PaymentFailedContent orderId={ORDER_ID} wasCancelled={true} />)
+
+    expect(screen.queryByRole('link', { name: /try again/i })).not.toBeInTheDocument()
+  })
+
+  it('renders the "Back to Cart" link when payment was cancelled', () => {
+    renderWithIntl(<PaymentFailedContent orderId={ORDER_ID} wasCancelled={true} />)
+
+    expect(screen.getByRole('link', { name: /back to cart/i })).toBeInTheDocument()
+  })
+})

--- a/apps/web/src/app/[locale]/checkout/confirmation/[orderId]/_components/payment-failed-content.tsx
+++ b/apps/web/src/app/[locale]/checkout/confirmation/[orderId]/_components/payment-failed-content.tsx
@@ -1,0 +1,44 @@
+import { useTranslations } from 'next-intl'
+import Link from 'next/link'
+import { XCircle } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+
+interface PaymentFailedContentProps {
+  orderId: string
+  wasCancelled: boolean
+}
+
+export function PaymentFailedContent({
+  orderId: _orderId,
+  wasCancelled,
+}: PaymentFailedContentProps) {
+  const t = useTranslations('confirmationPage')
+
+  const title = wasCancelled ? t('paymentCancelledTitle') : t('paymentFailedTitle')
+  const subtitle = wasCancelled ? t('paymentCancelledSubtitle') : t('paymentFailedSubtitle')
+
+  return (
+    <div className="space-y-6 text-center">
+      <div className="flex justify-center">
+        <XCircle className="size-16 text-destructive" aria-hidden="true" />
+      </div>
+
+      <div className="space-y-2">
+        <h1 className="text-2xl font-semibold text-foreground">{title}</h1>
+        <p className="text-muted-foreground">{subtitle}</p>
+      </div>
+
+      <div className="flex flex-col items-center gap-3 sm:flex-row sm:justify-center">
+        {!wasCancelled && (
+          <Button asChild size="lg">
+            {/* Cart is still saved in Zustand — going back to checkout starts a fresh attempt */}
+            <Link href="/checkout">{t('paymentFailedTryAgain')}</Link>
+          </Button>
+        )}
+        <Button asChild variant="outline" size="lg">
+          <Link href="/cart">{t('paymentFailedBackToCart')}</Link>
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/app/[locale]/checkout/confirmation/[orderId]/page.tsx
+++ b/apps/web/src/app/[locale]/checkout/confirmation/[orderId]/page.tsx
@@ -9,14 +9,40 @@ import { ConfirmationNextSteps } from './_components/confirmation-next-steps'
 import { ConfirmationOrderItems } from './_components/confirmation-order-items'
 import { ConfirmationOrderSummary } from './_components/confirmation-order-summary'
 import { ConfirmationSuccessHeader } from './_components/confirmation-success-header'
+import { PaymentFailedContent } from './_components/payment-failed-content'
 
 interface ConfirmationPageProps {
   params: Promise<{ locale: string; orderId: string }>
+  searchParams: Promise<{ redirect_status?: string }>
 }
 
-export async function generateMetadata({ params }: ConfirmationPageProps): Promise<Metadata> {
+export async function generateMetadata({
+  params,
+  searchParams,
+}: ConfirmationPageProps): Promise<Metadata> {
   const { locale } = await params
+  const { redirect_status } = await searchParams
   const t = await getTranslations({ locale, namespace: 'confirmationPage' })
+
+  const isPaymentFailed =
+    redirect_status === 'failed' || redirect_status === 'requires_payment_method'
+  const isPaymentCancelled = redirect_status === 'canceled'
+
+  if (isPaymentFailed) {
+    return {
+      title: t('paymentFailedMetaTitle'),
+      description: t('paymentFailedMetaDescription'),
+      robots: { index: false, follow: false },
+    }
+  }
+
+  if (isPaymentCancelled) {
+    return {
+      title: t('paymentCancelledTitle'),
+      description: t('paymentFailedMetaDescription'),
+      robots: { index: false, follow: false },
+    }
+  }
 
   return {
     title: t('metaTitle'),
@@ -25,8 +51,23 @@ export async function generateMetadata({ params }: ConfirmationPageProps): Promi
   }
 }
 
-export default async function ConfirmationPage({ params }: ConfirmationPageProps) {
+export default async function ConfirmationPage({ params, searchParams }: ConfirmationPageProps) {
   const { orderId } = await params
+  const { redirect_status } = await searchParams
+
+  // Stripe appends redirect_status to return_url after 3DS or redirect-based payment flows.
+  // "requires_payment_method" means the PaymentIntent was reset after a failed attempt.
+  const isPaymentFailed =
+    redirect_status === 'failed' || redirect_status === 'requires_payment_method'
+  const isPaymentCancelled = redirect_status === 'canceled'
+
+  if (isPaymentFailed || isPaymentCancelled) {
+    return (
+      <main className="mx-auto max-w-2xl px-4 py-12 sm:px-6">
+        <PaymentFailedContent orderId={orderId} wasCancelled={isPaymentCancelled} />
+      </main>
+    )
+  }
 
   let order
   try {


### PR DESCRIPTION
…us on confirmation page #31

## Why

<!-- What problem does this PR solve? Link to the issue. -->

Closes #

## What changed

<!-- List the key changes. Be specific. -->

-

## How to test

<!-- Steps to verify the change works correctly. -->

1.

## Checklist

- [ ] No `any` types in TypeScript
- [ ] `pnpm lint` passes
- [ ] `pnpm build` passes locally
- [ ] Self-reviewed the diff before opening PR
