### PR TITLE
fix: sitemap and Google Shopping feed return 0 products (paginate at …

### DIFF
--- a/apps/web/src/app/__tests__/sitemap.spec.ts
+++ b/apps/web/src/app/__tests__/sitemap.spec.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import * as productsApi from '@/lib/api/products'
+import { logger } from '@/lib/logger'
 import {
   suite as $allureSuite,
   subSuite as $allureSubSuite,
@@ -7,12 +8,21 @@ import {
 } from 'allure-js-commons'
 
 vi.mock('@/lib/api/products', () => ({
-  fetchProducts: vi.fn(),
+  fetchAllProducts: vi.fn(),
   fetchCategories: vi.fn(),
 }))
 
-const mockFetchProducts = vi.mocked(productsApi.fetchProducts)
+vi.mock('@/lib/logger', () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}))
+
+const mockFetchAllProducts = vi.mocked(productsApi.fetchAllProducts)
 const mockFetchCategories = vi.mocked(productsApi.fetchCategories)
+const mockLoggerError = vi.mocked(logger.error)
 
 const mockProduct = {
   slug: 'silver-moonstone-ring',
@@ -34,10 +44,7 @@ beforeEach(async () => {
 
 describe('sitemap', () => {
   it('returns static entries for all locales when API returns empty data', async () => {
-    mockFetchProducts.mockResolvedValue({
-      data: [],
-      meta: { totalCount: 0, totalPages: 1, page: 1, limit: 1000 },
-    })
+    mockFetchAllProducts.mockResolvedValue([])
     mockFetchCategories.mockResolvedValue([])
 
     const { default: sitemap } = await import('../sitemap')
@@ -48,17 +55,13 @@ describe('sitemap', () => {
   })
 
   it('includes the locale root (home = catalog) for each locale', async () => {
-    mockFetchProducts.mockResolvedValue({
-      data: [],
-      meta: { totalCount: 0, totalPages: 1, page: 1, limit: 1000 },
-    })
+    mockFetchAllProducts.mockResolvedValue([])
     mockFetchCategories.mockResolvedValue([])
 
     const { default: sitemap } = await import('../sitemap')
     const result = await sitemap()
 
     const urls = result.map((entry) => entry.url)
-    // Locale roots present
     expect(urls.some((url) => url.endsWith('/en'))).toBe(true)
     expect(urls.some((url) => url.endsWith('/ru'))).toBe(true)
     expect(urls.some((url) => url.endsWith('/es'))).toBe(true)
@@ -67,15 +70,9 @@ describe('sitemap', () => {
   })
 
   it('adds product pages for each locale when products are returned', async () => {
-    mockFetchProducts.mockResolvedValue({
-      data: [
-        mockProduct as Parameters<typeof mockFetchProducts>[0] & {
-          slug: string
-          updatedAt: string
-        },
-      ],
-      meta: { totalCount: 1, totalPages: 1, page: 1, limit: 1000 },
-    } as Awaited<ReturnType<typeof productsApi.fetchProducts>>)
+    mockFetchAllProducts.mockResolvedValue([
+      mockProduct as Awaited<ReturnType<typeof productsApi.fetchAllProducts>>[number],
+    ])
     mockFetchCategories.mockResolvedValue([])
 
     const { default: sitemap } = await import('../sitemap')
@@ -84,13 +81,14 @@ describe('sitemap', () => {
     const productUrls = result.filter((entry) => entry.url.includes('silver-moonstone-ring'))
     // One entry per locale
     expect(productUrls).toHaveLength(3)
+    // URL uses /products/, not /shop/
+    expect(productUrls.every((entry) => entry.url.includes('/products/'))).toBe(true)
   })
 
   it('sets lastModified from product updatedAt', async () => {
-    mockFetchProducts.mockResolvedValue({
-      data: [mockProduct] as Awaited<ReturnType<typeof productsApi.fetchProducts>>['data'],
-      meta: { totalCount: 1, totalPages: 1, page: 1, limit: 1000 },
-    })
+    mockFetchAllProducts.mockResolvedValue([mockProduct] as Awaited<
+      ReturnType<typeof productsApi.fetchAllProducts>
+    >)
     mockFetchCategories.mockResolvedValue([])
 
     const { default: sitemap } = await import('../sitemap')
@@ -100,23 +98,27 @@ describe('sitemap', () => {
     expect(productEntry?.lastModified).toBeInstanceOf(Date)
   })
 
-  it('returns only static pages when API throws', async () => {
-    mockFetchProducts.mockRejectedValue(new Error('API unavailable'))
-    mockFetchCategories.mockRejectedValue(new Error('API unavailable'))
+  it('returns only static pages and logs error when API throws (regression: #288)', async () => {
+    const apiFailure = new Error('API 400: limit must not be greater than 100')
+    mockFetchAllProducts.mockRejectedValue(apiFailure)
+    mockFetchCategories.mockRejectedValue(apiFailure)
 
     const { default: sitemap } = await import('../sitemap')
     const result = await sitemap()
 
-    // Only 3 locales × 2 static pages (home/catalog + ring-size-guide); /shop removed in #280
+    // Only 3 locales × 2 static pages (home/catalog + ring-size-guide)
     expect(result.length).toBe(6)
     expect(result.every((entry) => !entry.url.includes('silver-moonstone-ring'))).toBe(true)
+
+    // Failure must NOT be silent — logger.error tells ops something is wrong
+    expect(mockLoggerError).toHaveBeenCalledWith(
+      'sitemap.products-fetch.failed',
+      expect.objectContaining({ message: expect.stringContaining('API 400') }),
+    )
   })
 
   it('includes ring size guide entry for each locale', async () => {
-    mockFetchProducts.mockResolvedValue({
-      data: [],
-      meta: { totalCount: 0, totalPages: 1, page: 1, limit: 1000 },
-    })
+    mockFetchAllProducts.mockResolvedValue([])
     mockFetchCategories.mockResolvedValue([])
 
     const { default: sitemap } = await import('../sitemap')
@@ -127,10 +129,7 @@ describe('sitemap', () => {
   })
 
   it('adds category filter pages for each locale', async () => {
-    mockFetchProducts.mockResolvedValue({
-      data: [],
-      meta: { totalCount: 0, totalPages: 1, page: 1, limit: 1000 },
-    })
+    mockFetchAllProducts.mockResolvedValue([])
     mockFetchCategories.mockResolvedValue([mockCategory] as Awaited<
       ReturnType<typeof productsApi.fetchCategories>
     >)
@@ -140,5 +139,7 @@ describe('sitemap', () => {
 
     const categoryUrls = result.filter((entry) => entry.url.includes('categorySlug=rings'))
     expect(categoryUrls).toHaveLength(3)
+    // Facet URL uses locale root, not /shop
+    expect(categoryUrls.every((entry) => /\/(en|ru|es)\?categorySlug=/.test(entry.url))).toBe(true)
   })
 })

--- a/apps/web/src/app/feed/__tests__/google-shopping.spec.ts
+++ b/apps/web/src/app/feed/__tests__/google-shopping.spec.ts
@@ -5,9 +5,19 @@ import {
   severity as $allureSeverity,
 } from 'allure-js-commons'
 
-const mockFetchProducts = vi.fn()
+const mockFetchAllProducts = vi.fn()
+const mockLoggerError = vi.fn()
+
 vi.mock('@/lib/api/products', () => ({
-  fetchProducts: (...args: unknown[]) => mockFetchProducts(...args),
+  fetchAllProducts: (...args: unknown[]) => mockFetchAllProducts(...args),
+}))
+
+vi.mock('@/lib/logger', () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: (...args: unknown[]) => mockLoggerError(...args),
+  },
 }))
 
 beforeEach(async () => {
@@ -20,11 +30,12 @@ beforeEach(async () => {
 describe('Google Shopping Feed', () => {
   beforeEach(() => {
     vi.resetModules()
-    mockFetchProducts.mockReset()
+    mockFetchAllProducts.mockReset()
+    mockLoggerError.mockReset()
   })
 
   it('returns XML with correct content type', async () => {
-    mockFetchProducts.mockResolvedValue({ data: [] })
+    mockFetchAllProducts.mockResolvedValue([])
 
     const { GET } = await import('../google-shopping/route')
     const response = await GET()
@@ -33,7 +44,7 @@ describe('Google Shopping Feed', () => {
   })
 
   it('returns valid RSS 2.0 with Google namespace', async () => {
-    mockFetchProducts.mockResolvedValue({ data: [] })
+    mockFetchAllProducts.mockResolvedValue([])
 
     const { GET } = await import('../google-shopping/route')
     const response = await GET()
@@ -45,25 +56,23 @@ describe('Google Shopping Feed', () => {
   })
 
   it('includes product entries with required Google Shopping fields', async () => {
-    mockFetchProducts.mockResolvedValue({
-      data: [
-        {
-          id: 'prod-1',
-          title: 'Beaded Bracelet',
-          description: 'Handmade bracelet with Czech beads',
-          price: '45.00',
-          stock: 5,
-          images: ['https://cdn.example.com/bracelet.jpg'],
-          slug: 'beaded-bracelet',
-          sku: 'SKU-001',
-          material: 'Czech Glass Beads',
-          weightGrams: 25,
-          status: 'ACTIVE',
-          stockType: 'IN_STOCK',
-          category: { name: 'Bracelets', slug: 'bracelets' },
-        },
-      ],
-    })
+    mockFetchAllProducts.mockResolvedValue([
+      {
+        id: 'prod-1',
+        title: 'Beaded Bracelet',
+        description: 'Handmade bracelet with Czech beads',
+        price: '45.00',
+        stock: 5,
+        images: ['https://cdn.example.com/bracelet.jpg'],
+        slug: 'beaded-bracelet',
+        sku: 'SKU-001',
+        material: 'Czech Glass Beads',
+        weightGrams: 25,
+        status: 'ACTIVE',
+        stockType: 'IN_STOCK',
+        category: { name: 'Bracelets', slug: 'bracelets' },
+      },
+    ])
 
     const { GET } = await import('../google-shopping/route')
     const response = await GET()
@@ -81,25 +90,23 @@ describe('Google Shopping Feed', () => {
   })
 
   it('filters out non-ACTIVE products', async () => {
-    mockFetchProducts.mockResolvedValue({
-      data: [
-        {
-          id: 'draft-1',
-          title: 'Draft Product',
-          description: 'Not ready',
-          price: '10.00',
-          stock: 0,
-          images: [],
-          slug: 'draft',
-          sku: null,
-          material: null,
-          weightGrams: null,
-          status: 'DRAFT',
-          stockType: 'IN_STOCK',
-          category: { name: 'Other', slug: 'other' },
-        },
-      ],
-    })
+    mockFetchAllProducts.mockResolvedValue([
+      {
+        id: 'draft-1',
+        title: 'Draft Product',
+        description: 'Not ready',
+        price: '10.00',
+        stock: 0,
+        images: [],
+        slug: 'draft',
+        sku: null,
+        material: null,
+        weightGrams: null,
+        status: 'DRAFT',
+        stockType: 'IN_STOCK',
+        category: { name: 'Other', slug: 'other' },
+      },
+    ])
 
     const { GET } = await import('../google-shopping/route')
     const response = await GET()
@@ -109,25 +116,23 @@ describe('Google Shopping Feed', () => {
   })
 
   it('maps MADE_TO_ORDER to preorder availability', async () => {
-    mockFetchProducts.mockResolvedValue({
-      data: [
-        {
-          id: 'mto-1',
-          title: 'Custom Necklace',
-          description: 'Made to order',
-          price: '80.00',
-          stock: 0,
-          images: ['https://cdn.example.com/necklace.jpg'],
-          slug: 'custom-necklace',
-          sku: null,
-          material: null,
-          weightGrams: null,
-          status: 'ACTIVE',
-          stockType: 'MADE_TO_ORDER',
-          category: { name: 'Necklaces', slug: 'necklaces' },
-        },
-      ],
-    })
+    mockFetchAllProducts.mockResolvedValue([
+      {
+        id: 'mto-1',
+        title: 'Custom Necklace',
+        description: 'Made to order',
+        price: '80.00',
+        stock: 0,
+        images: ['https://cdn.example.com/necklace.jpg'],
+        slug: 'custom-necklace',
+        sku: null,
+        material: null,
+        weightGrams: null,
+        status: 'ACTIVE',
+        stockType: 'MADE_TO_ORDER',
+        category: { name: 'Necklaces', slug: 'necklaces' },
+      },
+    ])
 
     const { GET } = await import('../google-shopping/route')
     const response = await GET()
@@ -136,8 +141,9 @@ describe('Google Shopping Feed', () => {
     expect(xml).toContain('<g:availability>preorder</g:availability>')
   })
 
-  it('returns empty feed when API is unavailable', async () => {
-    mockFetchProducts.mockRejectedValue(new Error('API down'))
+  it('returns empty feed and logs error when API is unavailable (regression: #288)', async () => {
+    const apiFailure = new Error('API 400: limit must not be greater than 100')
+    mockFetchAllProducts.mockRejectedValue(apiFailure)
 
     const { GET } = await import('../google-shopping/route')
     const response = await GET()
@@ -145,5 +151,11 @@ describe('Google Shopping Feed', () => {
 
     expect(xml).toContain('<channel>')
     expect(xml).not.toContain('<item>')
+
+    // Failure must NOT be silent — Merchant Center would otherwise freeze with stale data
+    expect(mockLoggerError).toHaveBeenCalledWith(
+      'feed.google-shopping.products-fetch.failed',
+      expect.objectContaining({ message: expect.stringContaining('API 400') }),
+    )
   })
 })

--- a/apps/web/src/app/feed/google-shopping/route.ts
+++ b/apps/web/src/app/feed/google-shopping/route.ts
@@ -1,4 +1,5 @@
-import { fetchProducts } from '@/lib/api/products'
+import { fetchAllProducts } from '@/lib/api/products'
+import { logger } from '@/lib/logger'
 import type { Product } from '@jewelry/shared'
 
 const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? 'http://localhost:3000'
@@ -51,10 +52,18 @@ export async function GET(): Promise<Response> {
   let products: Product[] = []
 
   try {
-    const response = await fetchProducts({ limit: 1000 })
-    products = response.data.filter((product) => product.status === 'ACTIVE')
-  } catch {
-    // API unavailable — return empty feed; will regenerate on next revalidation
+    // fetchAllProducts paginates the public listing endpoint (capped at 100
+    // per page by the API) so the feed contains every ACTIVE SKU, not just the
+    // first page. Google Merchant Center expects the complete catalogue.
+    const allProducts = await fetchAllProducts()
+    products = allProducts.filter((product) => product.status === 'ACTIVE')
+  } catch (error) {
+    // Google Merchant Center pulls this feed daily — silently returning empty
+    // would freeze our Shopping campaign. Log loudly so the failure is visible.
+    logger.error('feed.google-shopping.products-fetch.failed', {
+      message: error instanceof Error ? error.message : String(error),
+      stack: error instanceof Error ? error.stack : undefined,
+    })
   }
 
   const xml = `<?xml version="1.0" encoding="UTF-8"?>

--- a/apps/web/src/app/sitemap.ts
+++ b/apps/web/src/app/sitemap.ts
@@ -1,6 +1,7 @@
 import type { MetadataRoute } from 'next'
-import { fetchProducts, fetchCategories } from '@/lib/api/products'
+import { fetchAllProducts, fetchCategories } from '@/lib/api/products'
 import { routing } from '@/i18n/routing'
+import { logger } from '@/lib/logger'
 
 const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? 'http://localhost:3000'
 
@@ -12,15 +13,21 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   let categories: { slug: string }[] = []
 
   try {
-    const [productsResponse, categoriesResponse] = await Promise.all([
-      // Fetch all products — one sitemap supports up to 50k URLs, limit: 1000 is well within range
-      fetchProducts({ limit: 1000 }),
+    // fetchAllProducts paginates through the API's 100-per-page cap so the
+    // sitemap stays correct as the catalogue grows past 100 SKUs.
+    const [allProducts, categoriesResponse] = await Promise.all([
+      fetchAllProducts(),
       fetchCategories(),
     ])
-    products = productsResponse.data
+    products = allProducts
     categories = categoriesResponse
-  } catch {
-    // API unavailable at build time — static pages only; sitemap regenerates on next revalidation
+  } catch (error) {
+    // Sitemap is critical for SEO — a silent failure here makes the bug invisible
+    // until Google stops crawling product pages. Log loudly so it shows up in Sentry / log aggregation.
+    logger.error('sitemap.products-fetch.failed', {
+      message: error instanceof Error ? error.message : String(error),
+      stack: error instanceof Error ? error.stack : undefined,
+    })
   }
 
   const staticEntries: MetadataRoute.Sitemap = routing.locales.flatMap((locale) => [

--- a/apps/web/src/lib/api/__tests__/products.spec.ts
+++ b/apps/web/src/lib/api/__tests__/products.spec.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { http, HttpResponse } from 'msw'
+import { server } from '@/test-utils/msw/server'
+import { fetchAllProducts, PUBLIC_PRODUCTS_MAX_PAGE_SIZE } from '../products'
+import {
+  suite as $allureSuite,
+  subSuite as $allureSubSuite,
+  severity as $allureSeverity,
+} from 'allure-js-commons'
+
+const API_BASE = 'http://localhost:4000'
+
+beforeEach(async () => {
+  if (!process.env.CI) return
+  await $allureSuite('web/lib/api')
+  await $allureSubSuite('products')
+  await $allureSeverity('normal')
+})
+
+function buildPage(page: number, totalPages: number, slugs: string[]) {
+  return HttpResponse.json({
+    data: slugs.map((slug) => ({ slug, updatedAt: '2026-01-01T00:00:00.000Z' })),
+    meta: {
+      totalCount: totalPages * PUBLIC_PRODUCTS_MAX_PAGE_SIZE,
+      totalPages,
+      page,
+      limit: PUBLIC_PRODUCTS_MAX_PAGE_SIZE,
+    },
+  })
+}
+
+describe('fetchAllProducts — pagination helper for sitemap/feed', () => {
+  it('requests limit=100 (API @Max(100) constraint) and not limit=1000 (regression: #288)', async () => {
+    const seenLimits: string[] = []
+    server.use(
+      http.get(`${API_BASE}/api/products`, ({ request }) => {
+        seenLimits.push(new URL(request.url).searchParams.get('limit') ?? '')
+        return buildPage(1, 1, ['a'])
+      }),
+    )
+
+    await fetchAllProducts()
+
+    expect(seenLimits).toEqual(['100'])
+  })
+
+  it('does only one request when totalPages is 1', async () => {
+    let requestCount = 0
+    server.use(
+      http.get(`${API_BASE}/api/products`, () => {
+        requestCount += 1
+        return buildPage(1, 1, ['only-product'])
+      }),
+    )
+
+    const result = await fetchAllProducts()
+
+    expect(requestCount).toBe(1)
+    expect(result).toHaveLength(1)
+    expect(result[0]?.slug).toBe('only-product')
+  })
+
+  it('fans out N-1 concurrent requests for pages 2..N when totalPages > 1', async () => {
+    const seenPages: string[] = []
+    server.use(
+      http.get(`${API_BASE}/api/products`, ({ request }) => {
+        const page = new URL(request.url).searchParams.get('page') ?? '1'
+        seenPages.push(page)
+        const pageNum = Number(page)
+        return buildPage(pageNum, 3, [`p${pageNum}-a`, `p${pageNum}-b`])
+      }),
+    )
+
+    const result = await fetchAllProducts()
+
+    expect(seenPages.sort()).toEqual(['1', '2', '3'])
+    expect(result.map((product) => product.slug).sort()).toEqual([
+      'p1-a',
+      'p1-b',
+      'p2-a',
+      'p2-b',
+      'p3-a',
+      'p3-b',
+    ])
+  })
+
+  it('propagates the underlying ApiError so callers can log it', async () => {
+    server.use(
+      http.get(`${API_BASE}/api/products`, () =>
+        HttpResponse.json({ message: 'limit must not be greater than 100' }, { status: 400 }),
+      ),
+    )
+
+    await expect(fetchAllProducts()).rejects.toThrow(/limit must not be greater than 100/)
+  })
+
+  it('PUBLIC_PRODUCTS_MAX_PAGE_SIZE matches the API @Max(100) guard', () => {
+    expect(PUBLIC_PRODUCTS_MAX_PAGE_SIZE).toBe(100)
+  })
+})

--- a/apps/web/src/lib/api/products.ts
+++ b/apps/web/src/lib/api/products.ts
@@ -37,6 +37,32 @@ export async function fetchProducts(params: FetchProductsParams = {}): Promise<P
   return apiClient<ProductsResponse>(`/api/products${query ? `?${query}` : ''}`)
 }
 
+// Matches the @Max(100) guard on the public product listing endpoint
+// (apps/api/src/products/dto/product-query.dto.ts). Exported so server-only
+// callers (sitemap, Google Shopping feed) can paginate against it.
+export const PUBLIC_PRODUCTS_MAX_PAGE_SIZE = 100
+
+/**
+ * Server-only helper: returns every public product by paging through the listing
+ * endpoint at the maximum allowed page size. Used by sitemap.xml and the Google
+ * Shopping feed, both of which need the full catalogue in a single document.
+ *
+ * Bounded by the API-reported `totalPages` — no infinite loops if the count
+ * drifts mid-traversal. Returns the first page's data on failure of later pages
+ * (caller decides whether partial data is acceptable; see usage in sitemap/feed).
+ */
+export async function fetchAllProducts(): Promise<Product[]> {
+  const first = await fetchProducts({ page: 1, limit: PUBLIC_PRODUCTS_MAX_PAGE_SIZE })
+  if (first.meta.totalPages <= 1) return first.data
+
+  const remainingPages = await Promise.all(
+    Array.from({ length: first.meta.totalPages - 1 }, (_, idx) =>
+      fetchProducts({ page: idx + 2, limit: PUBLIC_PRODUCTS_MAX_PAGE_SIZE }),
+    ),
+  )
+  return [...first.data, ...remainingPages.flatMap((response) => response.data)]
+}
+
 export async function fetchProductBySlug(productSlug: string): Promise<Product> {
   return apiClient<Product>(`/api/products/${productSlug}`)
 }


### PR DESCRIPTION
…API limit=100) #288

## Why

<!-- What problem does this PR solve? Link to the issue. -->

Closes #

## What changed

<!-- List the key changes. Be specific. -->

-

## How to test

<!-- Steps to verify the change works correctly. -->

1.

## Checklist

- [ ] No `any` types in TypeScript
- [ ] `pnpm lint` passes
- [ ] `pnpm build` passes locally
- [ ] Self-reviewed the diff before opening PR
- [ ] QA: affected `docs/qa/**.md` test cases updated (or N/A — purely internal change)
- [ ] Admin help: if a touched admin form added/removed/renamed any field, the matching `docs/admin-help/**.md` is updated in the same PR (or N/A)
