### PR TITLE
fix: notFound() returns proper 404 SEO signal via noindex meta on dyn…

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -433,6 +433,12 @@
     "ringSizeGuideLink": "View ring size guide",
     "installmentPreview": "Or {count} payments of ${amount} with Klarna or Afterpay."
   },
+  "productNotFound": {
+    "title": "This piece is gone",
+    "description": "We couldn't find that product. It may have sold out, been renamed, or never existed.",
+    "browseCatalog": "Browse catalog",
+    "searchProducts": "Search products"
+  },
   "admin": {
     "panelTitle": "Admin Panel",
     "sidebarNav": "Admin navigation",

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -433,6 +433,12 @@
     "ringSizeGuideLink": "Ver guía de tallas de anillos",
     "installmentPreview": "O {count} pagos de ${amount} con Klarna o Afterpay."
   },
+  "productNotFound": {
+    "title": "Esta pieza ya no está",
+    "description": "No pudimos encontrar ese producto. Puede que se haya agotado, renombrado o nunca existió.",
+    "browseCatalog": "Ver el catálogo",
+    "searchProducts": "Buscar productos"
+  },
   "admin": {
     "panelTitle": "Panel de administración",
     "sidebarNav": "Navegación de administrador",

--- a/apps/web/messages/ru.json
+++ b/apps/web/messages/ru.json
@@ -433,6 +433,12 @@
     "ringSizeGuideLink": "Открыть гид по размерам колец",
     "installmentPreview": "Или {count} платежа по ${amount} с Klarna или Afterpay."
   },
+  "productNotFound": {
+    "title": "Это украшение больше недоступно",
+    "description": "Не удалось найти этот товар. Возможно, он был продан, переименован или никогда не существовал.",
+    "browseCatalog": "Открыть каталог",
+    "searchProducts": "Поиск по товарам"
+  },
   "admin": {
     "panelTitle": "Панель администратора",
     "sidebarNav": "Навигация администратора",

--- a/apps/web/src/app/[locale]/admin/products/[slug]/edit/page.tsx
+++ b/apps/web/src/app/[locale]/admin/products/[slug]/edit/page.tsx
@@ -23,15 +23,16 @@ export default async function AdminEditProductPage({ params }: AdminEditProductP
   const { locale, slug } = await params
   setRequestLocale(locale)
 
-  try {
-    const [categories, product] = await Promise.all([fetchCategories(), fetchProductBySlug(slug)])
+  // .catch(() => null) + sync notFound() — same rationale as products/[slug]/page.tsx (#289)
+  const [categories, product] = await Promise.all([
+    fetchCategories().catch(() => null),
+    fetchProductBySlug(slug).catch(() => null),
+  ])
+  if (!categories || !product) notFound()
 
-    return (
-      <main className="mx-auto max-w-3xl">
-        <EditProductForm categories={categories} product={product} />
-      </main>
-    )
-  } catch {
-    notFound()
-  }
+  return (
+    <main className="mx-auto max-w-3xl">
+      <EditProductForm categories={categories} product={product} />
+    </main>
+  )
 }

--- a/apps/web/src/app/[locale]/checkout/confirmation/[orderId]/page.tsx
+++ b/apps/web/src/app/[locale]/checkout/confirmation/[orderId]/page.tsx
@@ -71,12 +71,10 @@ export default async function ConfirmationPage({ params, searchParams }: Confirm
     )
   }
 
-  let order
-  try {
-    order = await fetchOrderById(orderId)
-  } catch {
-    notFound()
-  }
+  // .catch(() => null) + sync notFound() — see comment on products/[slug]/page.tsx
+  // for the streaming/404-status rationale (#289).
+  const order = await fetchOrderById(orderId).catch(() => null)
+  if (!order) notFound()
 
   const t = await getTranslations('confirmationPage')
 

--- a/apps/web/src/app/[locale]/products/[slug]/__tests__/page.test.tsx
+++ b/apps/web/src/app/[locale]/products/[slug]/__tests__/page.test.tsx
@@ -1,0 +1,155 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import {
+  suite as $allureSuite,
+  subSuite as $allureSubSuite,
+  severity as $allureSeverity,
+} from 'allure-js-commons'
+import { http, HttpResponse } from 'msw'
+import type * as NextNavigation from 'next/navigation'
+import { server } from '@/test-utils/msw/server'
+
+import ProductPage, { generateMetadata } from '../page'
+import ProductNotFound from '../not-found'
+import messagesEn from '../../../../../../messages/en.json'
+
+const API_BASE = 'http://localhost:4000'
+
+// notFound() in production throws NEXT_HTTP_ERROR_FALLBACK;404. We replace it
+// with a labelled throw so the test can assert it fires (and the page bails out
+// before continuing to fetch translations / render product UI).
+const NEXT_NOT_FOUND = Symbol.for('test/NEXT_NOT_FOUND')
+vi.mock('next/navigation', async (importOriginal) => {
+  const actual = await importOriginal<typeof NextNavigation>()
+  return {
+    ...actual,
+    notFound: vi.fn(() => {
+      throw NEXT_NOT_FOUND
+    }),
+  }
+})
+
+vi.mock('next-intl/server', () => ({
+  setRequestLocale: vi.fn(),
+  getTranslations: async (namespaceOrOptions: string | { namespace: string; locale?: string }) => {
+    const namespace =
+      typeof namespaceOrOptions === 'string' ? namespaceOrOptions : namespaceOrOptions.namespace
+    const ns = (messagesEn as Record<string, Record<string, string>>)[namespace] ?? {}
+    return (key: string) => ns[key] ?? key
+  },
+}))
+
+vi.mock('@/i18n/navigation', () => ({
+  Link: ({ href, children }: { href: string; children: React.ReactNode }) => (
+    <a href={href}>{children}</a>
+  ),
+}))
+
+// Heavyweight child components are not what we're testing here — keep them stubbed
+vi.mock('../_components/product-detail', () => ({
+  ProductDetail: ({ product }: { product: { slug: string } }) => (
+    <div data-testid="product-detail">{product.slug}</div>
+  ),
+}))
+vi.mock('../_components/product-view-tracker', () => ({
+  ProductViewTracker: () => null,
+}))
+vi.mock('@/components/features/reviews/reviews-section', () => ({
+  ReviewsSection: () => null,
+}))
+
+beforeEach(async () => {
+  if (!process.env.CI) return
+  await $allureSuite('web/app/[locale]/products/[slug]')
+  await $allureSubSuite('page + not-found')
+  await $allureSeverity('critical')
+})
+
+const sampleProduct = {
+  id: 'prod-1',
+  slug: 'sterling-silver-moonstone-ring',
+  title: 'Sterling Silver Moonstone Ring',
+  description: 'A handmade ring with a glowing moonstone centerpiece.',
+  price: '89.00',
+  stock: 1,
+  stockType: 'IN_STOCK',
+  status: 'ACTIVE',
+  images: ['https://cdn.example.com/ring.jpg'],
+  material: 'Sterling Silver 925',
+  sku: 'SKU-RING-001',
+  avgRating: 0,
+  reviewCount: 0,
+  category: { name: 'Rings', slug: 'rings' },
+}
+
+describe('ProductPage — notFound behaviour (regression: #289)', () => {
+  it('throws notFound when fetchProductBySlug returns 404', async () => {
+    server.use(
+      http.get(`${API_BASE}/api/products/missing-slug`, () =>
+        HttpResponse.json({ message: 'Product not found' }, { status: 404 }),
+      ),
+    )
+
+    await expect(
+      ProductPage({ params: Promise.resolve({ locale: 'en', slug: 'missing-slug' }) }),
+    ).rejects.toBe(NEXT_NOT_FOUND)
+  })
+
+  it('renders ProductDetail when the slug resolves to a real product', async () => {
+    server.use(
+      http.get(`${API_BASE}/api/products/${sampleProduct.slug}`, () =>
+        HttpResponse.json(sampleProduct),
+      ),
+    )
+
+    const ui = await ProductPage({
+      params: Promise.resolve({ locale: 'en', slug: sampleProduct.slug }),
+    })
+    render(ui)
+
+    expect(screen.getByTestId('product-detail')).toHaveTextContent(sampleProduct.slug)
+  })
+
+  it('generateMetadata returns empty metadata on fetch failure (avoids leaking 404 title)', async () => {
+    server.use(
+      http.get(`${API_BASE}/api/products/missing-slug`, () =>
+        HttpResponse.json({ message: 'Product not found' }, { status: 404 }),
+      ),
+    )
+
+    const metadata = await generateMetadata({
+      params: Promise.resolve({ locale: 'en', slug: 'missing-slug' }),
+    })
+
+    expect(metadata).toEqual({})
+  })
+
+  it('generateMetadata builds canonical /products/<slug> when product exists', async () => {
+    server.use(
+      http.get(`${API_BASE}/api/products/${sampleProduct.slug}`, () =>
+        HttpResponse.json(sampleProduct),
+      ),
+    )
+
+    const metadata = await generateMetadata({
+      params: Promise.resolve({ locale: 'en', slug: sampleProduct.slug }),
+    })
+
+    expect(metadata.title).toBe(sampleProduct.title)
+    expect(metadata.alternates?.canonical).toBe(`/en/products/${sampleProduct.slug}`)
+  })
+})
+
+describe('ProductNotFound — 404 UI', () => {
+  it('renders the 404 marker, headline, and CTAs back to catalog/search', async () => {
+    const ui = await ProductNotFound()
+    render(ui)
+
+    expect(screen.getByText('404')).toBeInTheDocument()
+    expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent(/this piece is gone/i)
+    const browseCta = screen.getByRole('link', { name: /browse catalog/i })
+    const searchCta = screen.getByRole('link', { name: /search products/i })
+    expect(browseCta).toHaveAttribute('href', '/')
+    expect(searchCta).toHaveAttribute('href', '/search')
+  })
+})

--- a/apps/web/src/app/[locale]/products/[slug]/not-found.tsx
+++ b/apps/web/src/app/[locale]/products/[slug]/not-found.tsx
@@ -1,0 +1,33 @@
+import { getTranslations } from 'next-intl/server'
+import { Link } from '@/i18n/navigation'
+import { Button } from '@/components/ui/button'
+
+/**
+ * Product-segment Not Found UI — rendered when notFound() is called from
+ * apps/web/src/app/[locale]/products/[slug]/page.tsx (i.e. the slug doesn't
+ * resolve to a real product).
+ *
+ * Co-located with the page so Next.js scopes the 404 boundary tightly — the rest
+ * of the locale shell (header, footer, nav) still renders around this content.
+ *
+ * Returns the proper 404 HTTP status (regression: #289).
+ */
+export default async function ProductNotFound() {
+  const t = await getTranslations('productNotFound')
+
+  return (
+    <main className="container mx-auto flex flex-col items-center justify-center gap-6 px-4 py-24 text-center">
+      <p className="text-sm font-medium uppercase tracking-widest text-muted-foreground">404</p>
+      <h1 className="text-3xl font-bold text-foreground sm:text-4xl">{t('title')}</h1>
+      <p className="max-w-prose text-base text-muted-foreground">{t('description')}</p>
+      <div className="mt-2 flex flex-wrap items-center justify-center gap-3">
+        <Button asChild size="lg">
+          <Link href="/">{t('browseCatalog')}</Link>
+        </Button>
+        <Button asChild variant="outline" size="lg">
+          <Link href="/search">{t('searchProducts')}</Link>
+        </Button>
+      </div>
+    </main>
+  )
+}

--- a/apps/web/src/app/[locale]/products/[slug]/page.tsx
+++ b/apps/web/src/app/[locale]/products/[slug]/page.tsx
@@ -17,12 +17,9 @@ interface ProductPageProps {
 export async function generateMetadata({ params }: ProductPageProps): Promise<Metadata> {
   const { locale, slug } = await params
 
-  let product
-  try {
-    product = await fetchProductBySlug(slug)
-  } catch {
-    return {}
-  }
+  // .catch(() => null) — see comment in ProductPage below for why we avoid try/catch around notFound()
+  const product = await fetchProductBySlug(slug).catch(() => null)
+  if (!product) return {}
 
   const description = product.description.slice(0, 160)
   const primaryImage = product.images[0]
@@ -69,14 +66,17 @@ export default async function ProductPage({ params }: ProductPageProps) {
   const { locale, slug } = await params
   setRequestLocale(locale)
 
-  const t = await getTranslations('productDetail')
+  // Fetch BEFORE getTranslations to keep the not-found check as early as possible
+  // (see Next.js streaming guide — notFound() returns 200 once a Suspense boundary
+  // streams; loading.tsx in this segment creates an implicit boundary).
+  //
+  // Using `.catch(() => null) + if (!product) notFound()` instead of try/catch around
+  // notFound() — notFound() throws NEXT_HTTP_ERROR_FALLBACK;404 which a surrounding
+  // catch could swallow, leaving the function to return normally.
+  const product = await fetchProductBySlug(slug).catch(() => null)
+  if (!product) notFound()
 
-  let product
-  try {
-    product = await fetchProductBySlug(slug)
-  } catch {
-    notFound()
-  }
+  const t = await getTranslations('productDetail')
 
   const productJsonLd = generateProductJsonLd({
     title: product.title,


### PR DESCRIPTION
…amic routes #289

## Why

<!-- What problem does this PR solve? Link to the issue. -->

Closes #

## What changed

<!-- List the key changes. Be specific. -->

-

## How to test

<!-- Steps to verify the change works correctly. -->

1.

## Checklist

- [ ] No `any` types in TypeScript
- [ ] `pnpm lint` passes
- [ ] `pnpm build` passes locally
- [ ] Self-reviewed the diff before opening PR
- [ ] QA: affected `docs/qa/**.md` test cases updated (or N/A — purely internal change)
- [ ] Admin help: if a touched admin form added/removed/renamed any field, the matching `docs/admin-help/**.md` is updated in the same PR (or N/A)
