### PR TITLE
chore: i18n cleanup — hardcoded strings + missing translations #283

### DIFF
--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -524,7 +524,7 @@
     "productsColTitle": "Título",
     "productsColStatus": "Estado",
     "productsColPrice": "Precio",
-    "productsColStock": "Stock",
+    "productsColStock": "Existencias",
     "productsColSku": "SKU",
     "productsColCreatedAt": "Creado",
     "productsColActions": "Acciones",

--- a/apps/web/messages/ru.json
+++ b/apps/web/messages/ru.json
@@ -887,7 +887,7 @@
     "inventoryBadgeInStock": "В наличии",
     "inventoryBadgeMadeToOrder": "Под заказ",
     "inventoryBadgeOneOfAKind": "Единственный",
-    "inventoryBadgeLowStock": "Low stock",
+    "inventoryBadgeLowStock": "Низкий запас",
     "inventoryEmpty": "Нет товаров по этим фильтрам",
     "inventoryStockEditAriaLabel": "Изменить остаток для {title}",
     "inventoryStockSaveError": "Не удалось обновить остаток",

--- a/apps/web/src/app/[locale]/layout.tsx
+++ b/apps/web/src/app/[locale]/layout.tsx
@@ -35,6 +35,7 @@ export default async function LocaleLayout({ children, params }: LocaleLayoutPro
   setRequestLocale(locale)
 
   const messages = await getMessages()
+  const t = await getTranslations({ locale, namespace: 'header' })
 
   const organizationJsonLd = generateOrganizationJsonLd()
 
@@ -51,8 +52,7 @@ export default async function LocaleLayout({ children, params }: LocaleLayoutPro
           href="#main-content"
           className="sr-only focus:not-sr-only focus:fixed focus:left-4 focus:top-4 focus:z-50 focus:rounded-md focus:bg-background focus:px-4 focus:py-2 focus:text-sm focus:font-medium focus:shadow-lg focus:outline-none focus:ring-2 focus:ring-ring"
         >
-          {/* translated in Header — reusing same string key */}
-          Skip to main content
+          {t('skipToMain')}
         </a>
         <Header />
         <main id="main-content" className="flex-1">

--- a/apps/web/src/app/global-error.tsx
+++ b/apps/web/src/app/global-error.tsx
@@ -11,6 +11,12 @@ interface GlobalErrorProps {
 // global-error.tsx replaces the root layout when an unhandled error occurs.
 // It must include <html> and <body> tags because the normal layout is bypassed.
 // Sentry captures the error here so crashes in the root layout are tracked.
+//
+// i18n EXEMPTION (#283): strings are intentionally English-only. This boundary
+// renders *before* the [locale] layout has set the request-locale context, so
+// neither next-intl messages nor a locale param are available. Showing a
+// generic English fallback is the industry norm for catastrophic-error pages
+// and preferable to crashing the fallback itself trying to load translations.
 export default function GlobalError({ error, reset }: GlobalErrorProps) {
   useEffect(() => {
     Sentry.captureException(error)

--- a/apps/web/src/i18n/README.md
+++ b/apps/web/src/i18n/README.md
@@ -1,0 +1,81 @@
+# i18n — translation policy
+
+How translations are organized in `apps/web/messages/{en,ru,es}.json` and which strings stay English on purpose.
+
+---
+
+## Structure
+
+- One JSON file per locale: `en.json`, `ru.json`, `es.json`.
+- **All three files must have identical key shape** (key parity). Adding a key to one means adding it to all three.
+- Keys are camelCase, grouped by namespace at the top level (`header`, `footer`, `cartPage`, `admin`, …).
+- Server Components: `await getTranslations({ locale, namespace: 'xyz' })`.
+- Client Components: `useTranslations('xyz')`.
+
+## What MUST be translated
+
+Anything a customer or admin reads while using the site in their chosen locale:
+
+- Page headings, paragraphs, button labels, form placeholders
+- Error messages, toast notifications, confirmation prompts
+- ARIA labels, `title` attributes, image `alt` text
+- Email subject lines and bodies
+- Validation messages from forms
+
+If a string is rendered inside JSX without `t('...')` and a customer can see it, it's a bug.
+
+## What stays English on purpose
+
+These exemptions exist because translation would harm clarity, not help it.
+
+### Universal technical identifiers
+
+These are lingua franca across all locales — translating them creates confusion, not localization.
+
+- `SKU`, `Slug`, `URL`, `ID`, `JSON`, `CSV`, `PDF`
+- Carrier names: `USPS`, `FedEx`, `UPS`, `DHL`
+- Brand and product names (always English: "Senichka", "Sterling Silver")
+- HTTP status codes, currency codes (USD, EUR, RUB), country codes (US, RU, ES)
+
+### E-commerce technical terms widely used as-is
+
+In Spanish (and Russian admin/finance contexts) some English words have become standard usage. They appear in receipts, accounting software, and bank statements unchanged. Translating them looks foreign, not native.
+
+- `Subtotal`, `Total` (used identically in Spanish — same spelling, same meaning)
+- `Email` (standard in both RU and ES tech contexts; "correo electrónico" only in formal copy)
+- `Stock` (Spanish admin tables; "Existencias" is also valid and preferred in customer-facing UI — applied in #283)
+
+The judgment call: **customer-facing copy** in cart/checkout/product detail leans toward localized terms; **admin column headers** lean toward the English-as-jargon convention.
+
+### Catastrophic-error fallbacks
+
+[`apps/web/src/app/global-error.tsx`](../app/global-error.tsx) is intentionally English-only. It renders **before** the `[locale]` layout has set the request-locale context, so neither next-intl messages nor a locale param are available. Showing a generic English fallback ("Something went wrong / Try again") is the industry norm — preferable to crashing the fallback itself trying to load translations.
+
+## Key naming conventions
+
+| Pattern                                      | Use for                                                                      |
+| -------------------------------------------- | ---------------------------------------------------------------------------- |
+| `<namespace>.<field>`                        | leaf string in a flat group                                                  |
+| `<namespace>.<entity>_<id>_<part>`           | parallel groups like FAQ Q&A (`faqPage.q_shippingTime_question` / `_answer`) |
+| `<namespace>.<entity>List` / `<entity>Empty` | list-rendering states                                                        |
+
+camelCase only. No kebab-case, no snake_case (except in machine-readable values like product slugs).
+
+## Catching regressions
+
+- `apps/web/src/components/shared/__tests__/internal-links.test.ts` flags hardcoded `/dead/routes`.
+- `apps/web/src/i18n/__tests__/parity.spec.ts` ensures key shape matches across all three locale files.
+- ESLint rule `react/jsx-no-literals` is **not** enabled (too noisy on legitimate non-text content), so reviewers should spot hardcoded strings in PRs.
+
+## Adding a new translation key — checklist
+
+1. Add the key to the closest existing namespace in `en.json`.
+2. Mirror it into `ru.json` and `es.json` with proper translations.
+3. Use it via `useTranslations()` or `getTranslations()` — never `t.raw()` for user-visible copy.
+4. Run `pnpm --filter web test:run -- src/i18n` to confirm parity.
+
+## When to update this file
+
+- Adding a new exemption category (e.g. medical disclaimers must stay English for legal reasons).
+- Changing the convention for an entire namespace (e.g. moving admin from English-as-jargon to fully translated).
+- New tooling for catching missing translations (lint rules, CI checks).

--- a/apps/web/src/i18n/__tests__/parity.spec.ts
+++ b/apps/web/src/i18n/__tests__/parity.spec.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect } from 'vitest'
+import en from '../../../messages/en.json'
+import ru from '../../../messages/ru.json'
+import es from '../../../messages/es.json'
+import {
+  suite as $allureSuite,
+  subSuite as $allureSubSuite,
+  severity as $allureSeverity,
+} from 'allure-js-commons'
+
+beforeEach(async () => {
+  if (!process.env.CI) return
+  await $allureSuite('web/i18n')
+  await $allureSubSuite('parity')
+  await $allureSeverity('normal')
+})
+
+type Tree = Record<string, unknown>
+
+function flatten(tree: Tree, prefix = ''): string[] {
+  const out: string[] = []
+  for (const [key, value] of Object.entries(tree)) {
+    const path = prefix ? `${prefix}.${key}` : key
+    if (value !== null && typeof value === 'object' && !Array.isArray(value)) {
+      out.push(...flatten(value as Tree, path))
+    } else {
+      out.push(path)
+    }
+  }
+  return out
+}
+
+const enKeys = flatten(en as Tree).sort()
+const ruKeys = flatten(ru as Tree).sort()
+const esKeys = flatten(es as Tree).sort()
+
+describe('i18n key parity — all locales share the same shape', () => {
+  it('en.json and ru.json have identical key sets', () => {
+    const onlyInEn = enKeys.filter((k) => !ruKeys.includes(k))
+    const onlyInRu = ruKeys.filter((k) => !enKeys.includes(k))
+    expect(onlyInEn, 'keys in en.json missing from ru.json').toEqual([])
+    expect(onlyInRu, 'keys in ru.json missing from en.json').toEqual([])
+  })
+
+  it('en.json and es.json have identical key sets', () => {
+    const onlyInEn = enKeys.filter((k) => !esKeys.includes(k))
+    const onlyInEs = esKeys.filter((k) => !enKeys.includes(k))
+    expect(onlyInEn, 'keys in en.json missing from es.json').toEqual([])
+    expect(onlyInEs, 'keys in es.json missing from en.json').toEqual([])
+  })
+
+  it('every locale has the same total count', () => {
+    expect(ruKeys.length).toBe(enKeys.length)
+    expect(esKeys.length).toBe(enKeys.length)
+  })
+
+  it('no leaf value is an empty string in any locale', () => {
+    const collectEmpty = (tree: Tree, locale: string): string[] => {
+      const empties: string[] = []
+      for (const path of flatten(tree)) {
+        const value = path.split('.').reduce<unknown>((acc, segment) => {
+          if (acc && typeof acc === 'object') return (acc as Tree)[segment]
+          return undefined
+        }, tree)
+        if (typeof value === 'string' && value.trim().length === 0) {
+          empties.push(`${locale}:${path}`)
+        }
+      }
+      return empties
+    }
+
+    expect([
+      ...collectEmpty(en as Tree, 'en'),
+      ...collectEmpty(ru as Tree, 'ru'),
+      ...collectEmpty(es as Tree, 'es'),
+    ]).toEqual([])
+  })
+})
+
+describe('i18n untranslated regression guards (#283)', () => {
+  // RU value WAS "Low stock" (English leaked into Russian admin). Must stay Russian.
+  it('ru.json admin.inventoryBadgeLowStock is in Russian, not "Low stock"', () => {
+    const value = (ru as { admin: { inventoryBadgeLowStock: string } }).admin.inventoryBadgeLowStock
+    expect(value).not.toBe('Low stock')
+    expect(value).toMatch(/[а-яёА-ЯЁ]/)
+  })
+
+  // ES admin tables prefer the localized "Existencias" over English-as-jargon "Stock"
+  it('es.json admin.productsColStock is "Existencias", not "Stock"', () => {
+    const value = (es as { admin: { productsColStock: string } }).admin.productsColStock
+    expect(value).toBe('Existencias')
+  })
+
+  // Layout skip-link must read from i18n — bug #283 had it hardcoded as "Skip to main content"
+  it('all three locales define header.skipToMain', () => {
+    expect((en as { header: { skipToMain: string } }).header.skipToMain).toBeTruthy()
+    expect((ru as { header: { skipToMain: string } }).header.skipToMain).toBeTruthy()
+    expect((es as { header: { skipToMain: string } }).header.skipToMain).toBeTruthy()
+  })
+})


### PR DESCRIPTION
## Why

<!-- What problem does this PR solve? Link to the issue. -->

Closes #

## What changed

<!-- List the key changes. Be specific. -->

-

## How to test

<!-- Steps to verify the change works correctly. -->

1.

## Checklist

- [ ] No `any` types in TypeScript
- [ ] `pnpm lint` passes
- [ ] `pnpm build` passes locally
- [ ] Self-reviewed the diff before opening PR
- [ ] QA: affected `docs/qa/**.md` test cases updated (or N/A — purely internal change)
- [ ] Admin help: if a touched admin form added/removed/renamed any field, the matching `docs/admin-help/**.md` is updated in the same PR (or N/A)
