### PR TITLE
feat: add x-default hreflang + centralise alternates builder #297

### DIFF
--- a/apps/web/src/app/[locale]/about/page.tsx
+++ b/apps/web/src/app/[locale]/about/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next'
 import { getTranslations, setRequestLocale } from 'next-intl/server'
+import { buildLocaleAlternates } from '@/lib/seo/alternates'
 import { Link } from '@/i18n/navigation'
 import { Button } from '@/components/ui/button'
 
@@ -14,10 +15,7 @@ export async function generateMetadata({ params }: AboutPageProps): Promise<Meta
   return {
     title: t('metaTitle'),
     description: t('metaDescription'),
-    alternates: {
-      canonical: `/${locale}/about`,
-      languages: { en: '/en/about', ru: '/ru/about', es: '/es/about' },
-    },
+    alternates: buildLocaleAlternates(locale, '/about'),
     openGraph: {
       title: t('metaTitle'),
       description: t('metaDescription'),

--- a/apps/web/src/app/[locale]/care/page.tsx
+++ b/apps/web/src/app/[locale]/care/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next'
 import { getTranslations, setRequestLocale } from 'next-intl/server'
+import { buildLocaleAlternates } from '@/lib/seo/alternates'
 
 interface CarePageProps {
   params: Promise<{ locale: string }>
@@ -12,10 +13,7 @@ export async function generateMetadata({ params }: CarePageProps): Promise<Metad
   return {
     title: t('metaTitle'),
     description: t('metaDescription'),
-    alternates: {
-      canonical: `/${locale}/care`,
-      languages: { en: '/en/care', ru: '/ru/care', es: '/es/care' },
-    },
+    alternates: buildLocaleAlternates(locale, '/care'),
     openGraph: {
       title: t('metaTitle'),
       description: t('metaDescription'),

--- a/apps/web/src/app/[locale]/contact/page.tsx
+++ b/apps/web/src/app/[locale]/contact/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next'
 import { getTranslations, setRequestLocale } from 'next-intl/server'
+import { buildLocaleAlternates } from '@/lib/seo/alternates'
 import { ContactForm } from './_components/contact-form'
 
 interface ContactPageProps {
@@ -13,10 +14,7 @@ export async function generateMetadata({ params }: ContactPageProps): Promise<Me
   return {
     title: t('metaTitle'),
     description: t('metaDescription'),
-    alternates: {
-      canonical: `/${locale}/contact`,
-      languages: { en: '/en/contact', ru: '/ru/contact', es: '/es/contact' },
-    },
+    alternates: buildLocaleAlternates(locale, '/contact'),
     openGraph: {
       title: t('metaTitle'),
       description: t('metaDescription'),

--- a/apps/web/src/app/[locale]/faq/__tests__/page.test.tsx
+++ b/apps/web/src/app/[locale]/faq/__tests__/page.test.tsx
@@ -95,13 +95,14 @@ describe('FaqPage — FAQPage JSON-LD (#282 SEO rich results)', () => {
 })
 
 describe('FaqPage — generateMetadata', () => {
-  it('returns canonical /<locale>/faq and hreflang for all 3 locales', async () => {
+  it('returns canonical /<locale>/faq + 4 hreflang alternates including x-default (#297)', async () => {
     const metadata = await generateMetadata({ params: Promise.resolve({ locale: 'en' }) })
     expect(metadata.alternates?.canonical).toBe('/en/faq')
     expect(metadata.alternates?.languages).toEqual({
       en: '/en/faq',
       ru: '/ru/faq',
       es: '/es/faq',
+      'x-default': '/en/faq',
     })
   })
 })

--- a/apps/web/src/app/[locale]/faq/page.tsx
+++ b/apps/web/src/app/[locale]/faq/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next'
 import { getTranslations, setRequestLocale } from 'next-intl/server'
+import { buildLocaleAlternates } from '@/lib/seo/alternates'
 import { generateFaqJsonLd } from '@/lib/seo/json-ld'
 
 // 9 question keys exposed as a const tuple so JSON-LD and the rendered
@@ -27,10 +28,7 @@ export async function generateMetadata({ params }: FaqPageProps): Promise<Metada
   return {
     title: t('metaTitle'),
     description: t('metaDescription'),
-    alternates: {
-      canonical: `/${locale}/faq`,
-      languages: { en: '/en/faq', ru: '/ru/faq', es: '/es/faq' },
-    },
+    alternates: buildLocaleAlternates(locale, '/faq'),
     openGraph: {
       title: t('metaTitle'),
       description: t('metaDescription'),

--- a/apps/web/src/app/[locale]/layout.tsx
+++ b/apps/web/src/app/[locale]/layout.tsx
@@ -9,6 +9,7 @@ import { Footer } from '@/components/shared/footer'
 import { StoreHydration } from '@/components/shared/store-hydration'
 import { QueryProvider } from '@/components/shared/query-provider'
 import { generateOrganizationJsonLd } from '@/lib/seo/json-ld'
+import { buildLocaleAlternates } from '@/lib/seo/alternates'
 import { CookieBanner } from '@/components/shared/cookie-banner'
 
 interface LocaleLayoutProps {
@@ -85,13 +86,9 @@ export async function generateMetadata({
       locale,
       siteName: t('title'),
     },
-    alternates: {
-      languages: {
-        en: '/en',
-        ru: '/ru',
-        es: '/es',
-      },
-    },
+    // Root layout has no canonical of its own — each page declares one — but it
+    // still emits hreflang alternates as a default for pages that don't override.
+    alternates: buildLocaleAlternates(undefined, ''),
   }
 }
 

--- a/apps/web/src/app/[locale]/login/page.tsx
+++ b/apps/web/src/app/[locale]/login/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next'
 import { getTranslations, setRequestLocale } from 'next-intl/server'
+import { buildLocaleAlternates } from '@/lib/seo/alternates'
 import { Link } from '@/i18n/navigation'
 import { LoginForm } from './_components/login-form'
 
@@ -14,9 +15,7 @@ export async function generateMetadata({ params }: LoginPageProps): Promise<Meta
   return {
     title: t('loginMetaTitle'),
     description: t('loginMetaDescription'),
-    alternates: {
-      canonical: `/${locale}/login`,
-    },
+    alternates: buildLocaleAlternates(locale, '/login'),
     openGraph: {
       title: t('loginMetaTitle'),
       description: t('loginMetaDescription'),

--- a/apps/web/src/app/[locale]/page.tsx
+++ b/apps/web/src/app/[locale]/page.tsx
@@ -2,6 +2,7 @@ import { Suspense } from 'react'
 import type { Metadata } from 'next'
 import { getTranslations, setRequestLocale } from 'next-intl/server'
 import { fetchProducts, fetchCategories } from '@/lib/api/products'
+import { buildLocaleAlternates } from '@/lib/seo/alternates'
 import { ProductGrid } from '@/components/features/catalog/product-grid'
 import { ProductGridSkeleton } from '@/components/features/catalog/product-grid-skeleton'
 import { CatalogHeader } from './_components/catalog-header'
@@ -41,11 +42,8 @@ export async function generateMetadata({ params }: HomePageProps): Promise<Metad
       type: 'website',
       url: `/${locale}`,
     },
-    alternates: {
-      // canonical points to the locale root — filter combinations must not create duplicate content
-      canonical: `/${locale}`,
-      languages: { en: '/en', ru: '/ru', es: '/es' },
-    },
+    // canonical points to the locale root — filter combinations must not create duplicate content
+    alternates: buildLocaleAlternates(locale, ''),
   }
 }
 

--- a/apps/web/src/app/[locale]/privacy/page.tsx
+++ b/apps/web/src/app/[locale]/privacy/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next'
 import { getTranslations, setRequestLocale } from 'next-intl/server'
+import { buildLocaleAlternates } from '@/lib/seo/alternates'
 
 interface PrivacyPageProps {
   params: Promise<{ locale: string }>
@@ -12,10 +13,7 @@ export async function generateMetadata({ params }: PrivacyPageProps): Promise<Me
   return {
     title: t('metaTitle'),
     description: t('metaDescription'),
-    alternates: {
-      canonical: `/${locale}/privacy`,
-      languages: { en: '/en/privacy', ru: '/ru/privacy', es: '/es/privacy' },
-    },
+    alternates: buildLocaleAlternates(locale, '/privacy'),
     openGraph: {
       title: t('metaTitle'),
       description: t('metaDescription'),

--- a/apps/web/src/app/[locale]/products/[slug]/__tests__/page.test.tsx
+++ b/apps/web/src/app/[locale]/products/[slug]/__tests__/page.test.tsx
@@ -137,6 +137,13 @@ describe('ProductPage — notFound behaviour (regression: #289)', () => {
 
     expect(metadata.title).toBe(sampleProduct.title)
     expect(metadata.alternates?.canonical).toBe(`/en/products/${sampleProduct.slug}`)
+    // #297 — x-default points international visitors to the EN version
+    expect(metadata.alternates?.languages).toEqual({
+      en: `/en/products/${sampleProduct.slug}`,
+      ru: `/ru/products/${sampleProduct.slug}`,
+      es: `/es/products/${sampleProduct.slug}`,
+      'x-default': `/en/products/${sampleProduct.slug}`,
+    })
   })
 })
 

--- a/apps/web/src/app/[locale]/products/[slug]/page.tsx
+++ b/apps/web/src/app/[locale]/products/[slug]/page.tsx
@@ -3,6 +3,7 @@ import type { Metadata } from 'next'
 import { getTranslations, setRequestLocale } from 'next-intl/server'
 import { fetchProductBySlug } from '@/lib/api/products'
 import { generateBreadcrumbJsonLd, generateProductJsonLd } from '@/lib/seo/json-ld'
+import { buildLocaleAlternates } from '@/lib/seo/alternates'
 import { ReviewsSection } from '@/components/features/reviews/reviews-section'
 import { ProductDetail } from './_components/product-detail'
 import { ProductViewTracker } from './_components/product-view-tracker'
@@ -51,14 +52,7 @@ export async function generateMetadata({ params }: ProductPageProps): Promise<Me
       ...(product.sku && { 'product:retailer_item_id': product.sku }),
     },
     // canonical prevents duplicate content across locales and filter combinations
-    alternates: {
-      canonical: `/${locale}/products/${slug}`,
-      languages: {
-        en: `/en/products/${slug}`,
-        ru: `/ru/products/${slug}`,
-        es: `/es/products/${slug}`,
-      },
-    },
+    alternates: buildLocaleAlternates(locale, `/products/${slug}`),
   }
 }
 

--- a/apps/web/src/app/[locale]/register/page.tsx
+++ b/apps/web/src/app/[locale]/register/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next'
 import { getTranslations, setRequestLocale } from 'next-intl/server'
+import { buildLocaleAlternates } from '@/lib/seo/alternates'
 import { Link } from '@/i18n/navigation'
 import { RegisterForm } from './_components/register-form'
 
@@ -14,9 +15,7 @@ export async function generateMetadata({ params }: RegisterPageProps): Promise<M
   return {
     title: t('registerMetaTitle'),
     description: t('registerMetaDescription'),
-    alternates: {
-      canonical: `/${locale}/register`,
-    },
+    alternates: buildLocaleAlternates(locale, '/register'),
     openGraph: {
       title: t('registerMetaTitle'),
       description: t('registerMetaDescription'),

--- a/apps/web/src/app/[locale]/ring-size-guide/page.tsx
+++ b/apps/web/src/app/[locale]/ring-size-guide/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next'
 import { getTranslations, setRequestLocale } from 'next-intl/server'
+import { buildLocaleAlternates } from '@/lib/seo/alternates'
 import { generateHowToJsonLd } from '@/lib/seo/json-ld'
 import { RingSizeTable } from './_components/ring-size-table'
 import { HowToMeasure } from './_components/how-to-measure'
@@ -15,14 +16,7 @@ export async function generateMetadata({ params }: RingSizeGuidePageProps): Prom
   return {
     title: t('metaTitle'),
     description: t('metaDescription'),
-    alternates: {
-      canonical: `/${locale}/ring-size-guide`,
-      languages: {
-        en: '/en/ring-size-guide',
-        ru: '/ru/ring-size-guide',
-        es: '/es/ring-size-guide',
-      },
-    },
+    alternates: buildLocaleAlternates(locale, '/ring-size-guide'),
     openGraph: {
       title: t('metaTitle'),
       description: t('metaDescription'),

--- a/apps/web/src/app/[locale]/shipping/page.tsx
+++ b/apps/web/src/app/[locale]/shipping/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next'
 import { getTranslations, setRequestLocale } from 'next-intl/server'
+import { buildLocaleAlternates } from '@/lib/seo/alternates'
 
 interface ShippingPageProps {
   params: Promise<{ locale: string }>
@@ -12,10 +13,7 @@ export async function generateMetadata({ params }: ShippingPageProps): Promise<M
   return {
     title: t('metaTitle'),
     description: t('metaDescription'),
-    alternates: {
-      canonical: `/${locale}/shipping`,
-      languages: { en: '/en/shipping', ru: '/ru/shipping', es: '/es/shipping' },
-    },
+    alternates: buildLocaleAlternates(locale, '/shipping'),
     openGraph: {
       title: t('metaTitle'),
       description: t('metaDescription'),

--- a/apps/web/src/app/[locale]/terms/page.tsx
+++ b/apps/web/src/app/[locale]/terms/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next'
 import { getTranslations, setRequestLocale } from 'next-intl/server'
+import { buildLocaleAlternates } from '@/lib/seo/alternates'
 import Link from 'next/link'
 
 interface TermsPageProps {
@@ -13,10 +14,7 @@ export async function generateMetadata({ params }: TermsPageProps): Promise<Meta
   return {
     title: t('metaTitle'),
     description: t('metaDescription'),
-    alternates: {
-      canonical: `/${locale}/terms`,
-      languages: { en: '/en/terms', ru: '/ru/terms', es: '/es/terms' },
-    },
+    alternates: buildLocaleAlternates(locale, '/terms'),
     openGraph: {
       title: t('metaTitle'),
       description: t('metaDescription'),

--- a/apps/web/src/lib/seo/__tests__/alternates.spec.ts
+++ b/apps/web/src/lib/seo/__tests__/alternates.spec.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from 'vitest'
+import {
+  suite as $allureSuite,
+  subSuite as $allureSubSuite,
+  severity as $allureSeverity,
+} from 'allure-js-commons'
+import { buildLocaleAlternates } from '../alternates'
+
+beforeEach(async () => {
+  if (!process.env.CI) return
+  await $allureSuite('web/lib/seo')
+  await $allureSubSuite('alternates')
+  await $allureSeverity('normal')
+})
+
+describe('buildLocaleAlternates', () => {
+  it('returns canonical and 4 alternates for a static page', () => {
+    const result = buildLocaleAlternates('en', '/contact')
+
+    expect(result.canonical).toBe('/en/contact')
+    expect(result.languages).toEqual({
+      en: '/en/contact',
+      ru: '/ru/contact',
+      es: '/es/contact',
+      'x-default': '/en/contact',
+    })
+  })
+
+  it('handles the locale root (empty path)', () => {
+    const result = buildLocaleAlternates('ru', '')
+
+    expect(result.canonical).toBe('/ru')
+    expect(result.languages).toEqual({
+      en: '/en',
+      ru: '/ru',
+      es: '/es',
+      'x-default': '/en',
+    })
+  })
+
+  it('interpolates a dynamic slug into all alternates', () => {
+    const result = buildLocaleAlternates('es', '/products/silver-ring')
+
+    expect(result.canonical).toBe('/es/products/silver-ring')
+    expect(result.languages['x-default']).toBe('/en/products/silver-ring')
+    expect(result.languages.es).toBe('/es/products/silver-ring')
+  })
+
+  it('omits canonical when locale is undefined (root layout default metadata)', () => {
+    const result = buildLocaleAlternates(undefined, '')
+
+    expect(result.canonical).toBeUndefined()
+    expect(result.languages).toEqual({
+      en: '/en',
+      ru: '/ru',
+      es: '/es',
+      'x-default': '/en',
+    })
+  })
+
+  it('x-default ALWAYS points to the default locale (en), not the current locale', () => {
+    // Visiting Spanish page → x-default still points to /en
+    const fromEs = buildLocaleAlternates('es', '/faq')
+    expect(fromEs.languages['x-default']).toBe('/en/faq')
+
+    // Visiting Russian page → x-default still points to /en
+    const fromRu = buildLocaleAlternates('ru', '/faq')
+    expect(fromRu.languages['x-default']).toBe('/en/faq')
+  })
+
+  it('emits exactly 4 language keys (3 locales + x-default)', () => {
+    const result = buildLocaleAlternates('en', '/about')
+    expect(Object.keys(result.languages).sort()).toEqual(['en', 'es', 'ru', 'x-default'])
+  })
+})

--- a/apps/web/src/lib/seo/alternates.ts
+++ b/apps/web/src/lib/seo/alternates.ts
@@ -1,0 +1,41 @@
+import { routing } from '@/i18n/routing'
+
+/**
+ * Builds the `alternates` block for Next.js `Metadata`. Used by every
+ * locale-aware page so SEO tags stay consistent (canonical + hreflang).
+ *
+ * Includes `x-default` per Google's international SEO recommendation
+ * (https://developers.google.com/search/docs/specialty/international/localized-versions):
+ * visitors whose Accept-Language does not match en/ru/es are routed to the
+ * default locale (en). Without `x-default`, Google still picks one of the
+ * explicit alternates, but mis-routes more often.
+ *
+ * @param locale - The locale of the currently rendered page. Pass `undefined`
+ *                 for the root layout metadata (which has no own canonical —
+ *                 each page renders its own).
+ * @param path   - The route path WITHOUT the locale prefix. Use an empty string
+ *                 for the locale root. Examples:
+ *                   ""                          → /en, /ru, /es
+ *                   "/contact"                  → /en/contact, /ru/contact, …
+ *                   "/products/silver-ring"     → /en/products/silver-ring, …
+ *
+ * The returned shape is structurally compatible with `Metadata['alternates']`.
+ */
+export function buildLocaleAlternates(
+  locale: string | undefined,
+  path: string,
+): { canonical?: string; languages: Record<string, string> } {
+  const languages: Record<string, string> = {}
+  for (const loc of routing.locales) {
+    languages[loc] = `/${loc}${path}`
+  }
+  languages['x-default'] = `/${routing.defaultLocale}${path}`
+
+  if (locale === undefined) {
+    return { languages }
+  }
+  return {
+    canonical: `/${locale}${path}`,
+    languages,
+  }
+}


### PR DESCRIPTION
## Why

<!-- What problem does this PR solve? Link to the issue. -->

Closes #

## What changed

<!-- List the key changes. Be specific. -->

-

## How to test

<!-- Steps to verify the change works correctly. -->

1.

## Checklist

- [ ] No `any` types in TypeScript
- [ ] `pnpm lint` passes
- [ ] `pnpm build` passes locally
- [ ] Self-reviewed the diff before opening PR
- [ ] QA: affected `docs/qa/**.md` test cases updated (or N/A — purely internal change)
- [ ] Admin help: if a touched admin form added/removed/renamed any field, the matching `docs/admin-help/**.md` is updated in the same PR (or N/A)
