### PR TITLE
chore: comment audit — drop water across admin panel (Round 2) #317

### DIFF
--- a/apps/web/src/app/[locale]/admin/_components/__tests__/revenue-chart.test.tsx
+++ b/apps/web/src/app/[locale]/admin/_components/__tests__/revenue-chart.test.tsx
@@ -19,14 +19,13 @@ vi.mock('@/store/auth.store', () => ({
     selector({ accessToken: 'mock-token' }),
 }))
 
-// recharts uses ResizeObserver internally
+// recharts needs ResizeObserver, and ResponsiveContainer doesn't work in jsdom.
 global.ResizeObserver = vi.fn().mockImplementation(() => ({
   observe: vi.fn(),
   unobserve: vi.fn(),
   disconnect: vi.fn(),
 }))
 
-// ResponsiveContainer doesn't work in jsdom — stub recharts chart components
 vi.mock('recharts', async (importOriginal) => {
   const actual = await importOriginal<typeof Recharts>()
   return {

--- a/apps/web/src/app/[locale]/admin/_components/admin-auth-guard.tsx
+++ b/apps/web/src/app/[locale]/admin/_components/admin-auth-guard.tsx
@@ -8,26 +8,16 @@ interface AdminAuthGuardProps {
   children: React.ReactNode
 }
 
-/**
- * Client-side ADMIN role guard.
- * Tokens live in localStorage (Zustand persist), so role checks must happen
- * on the client after hydration — not in Server Components or middleware.
- * Redirects non-authenticated and non-ADMIN users to the home page.
- *
- * isHydrated flag prevents premature redirect before Zustand rehydrates from
- * localStorage — without it the guard sees isAuthenticated=false on first render
- * and redirects before StoreHydration's useEffect fires.
- */
+// Tokens live in localStorage via Zustand persist, so role checks must happen
+// client-side AFTER hydration — the isHydrated gate blocks a premature redirect
+// before StoreHydration's rehydrate() runs.
 export function AdminAuthGuard({ children }: AdminAuthGuardProps) {
   const isAuthenticated = useAuthStore((state) => state.isAuthenticated)
   const role = useAuthStore((state) => state.role)
   const router = useRouter()
-  // Start as hydrated=false to block redirect until client useEffect runs
   const [isHydrated, setIsHydrated] = useState(false)
 
   useEffect(() => {
-    // Mark hydrated after first client render — by this point StoreHydration's
-    // useEffect has already called rehydrate(), so auth state is populated
     setIsHydrated(true)
   }, [])
 

--- a/apps/web/src/app/[locale]/admin/_components/admin-sidebar.tsx
+++ b/apps/web/src/app/[locale]/admin/_components/admin-sidebar.tsx
@@ -27,10 +27,8 @@ export function AdminSidebar() {
   const pathname = usePathname()
   const accessToken = useAuthStore((state) => state.accessToken)
 
-  // Lightweight badge query — separate endpoint returning just { count } so we
-  // don't load the full inventory payload on every admin page navigation.
-  // Refetch every 2 minutes to keep the indicator reasonably fresh as orders
-  // come in. Window-focus refetch covers the "I returned from another tab" case.
+  // Separate count-only endpoint so we don't load the full inventory payload
+  // on every admin navigation.
   const { data: lowStockData } = useQuery({
     queryKey: ['admin-low-stock-count'],
     queryFn: () => fetchLowStockCount(accessToken ?? ''),
@@ -40,15 +38,13 @@ export function AdminSidebar() {
   })
   const lowStockCount = lowStockData?.count ?? 0
 
-  // Hrefs are locale-agnostic — `Link` from `@/i18n/navigation` prepends the
-  // active locale automatically. Including `/${locale}` here produced a
-  // double-locale URL like `/en/en/admin/products` and 404'd.
+  // Hrefs are locale-agnostic — Link prepends the active locale; including
+  // `/${locale}` here would produce `/en/en/admin/...` and 404.
   const sidebarLinks = [
     {
       href: '/admin',
       labelKey: 'navDashboard' as const,
       icon: <LayoutDashboard className="size-4" aria-hidden="true" />,
-      // Dashboard is active only on exact /admin path, not on sub-pages
       isActive: pathname === '/admin',
     },
     {
@@ -67,7 +63,7 @@ export function AdminSidebar() {
       href: '/admin/orders',
       labelKey: 'navOrders' as const,
       icon: <ShoppingCart className="size-4" aria-hidden="true" />,
-      // Match /admin/orders but not the dedicated sub-routes (refunds, production).
+      // Excluded sub-routes have their own sidebar entries below.
       isActive:
         pathname.startsWith('/admin/orders') &&
         !pathname.startsWith('/admin/orders/refunds') &&

--- a/apps/web/src/app/[locale]/admin/_components/analytics/__tests__/key-metrics-cards.test.tsx
+++ b/apps/web/src/app/[locale]/admin/_components/analytics/__tests__/key-metrics-cards.test.tsx
@@ -82,7 +82,6 @@ describe('KeyMetricsCards', () => {
 
     render(<KeyMetricsCards period="30d" />)
 
-    // Four ellipses, one per metric card
     const placeholders = screen.getAllByText('…')
     expect(placeholders).toHaveLength(4)
   })

--- a/apps/web/src/app/[locale]/admin/_components/analytics/__tests__/order-status-breakdown.test.tsx
+++ b/apps/web/src/app/[locale]/admin/_components/analytics/__tests__/order-status-breakdown.test.tsx
@@ -18,7 +18,6 @@ vi.mock('@/store/auth.store', () => ({
     selector({ accessToken: 'mock-token' }),
 }))
 
-// recharts uses ResizeObserver internally
 global.ResizeObserver = vi.fn().mockImplementation(() => ({
   observe: vi.fn(),
   unobserve: vi.fn(),
@@ -69,7 +68,6 @@ describe('OrderStatusBreakdown', () => {
 
     render(<OrderStatusBreakdown period="30d" />)
 
-    // Pending and Delivered should both show even though Pending has 0
     expect(await screen.findByText('Pending')).toBeInTheDocument()
     expect(screen.getByText('Delivered')).toBeInTheDocument()
     expect(screen.getByText('7')).toBeInTheDocument()

--- a/apps/web/src/app/[locale]/admin/_components/analytics/__tests__/top-products-table.test.tsx
+++ b/apps/web/src/app/[locale]/admin/_components/analytics/__tests__/top-products-table.test.tsx
@@ -29,8 +29,6 @@ vi.mock('@/i18n/navigation', () => ({
   ),
 }))
 
-// Stub next/image — its full feature set isn't necessary for these tests
-// and CDN-relative `src` paths trigger jsdom warnings otherwise.
 vi.mock('next/image', () => ({
   default: ({ alt }: { alt: string }) => <span data-testid="product-image" aria-label={alt} />,
 }))

--- a/apps/web/src/app/[locale]/admin/_components/analytics/order-status-breakdown.tsx
+++ b/apps/web/src/app/[locale]/admin/_components/analytics/order-status-breakdown.tsx
@@ -12,9 +12,7 @@ interface OrderStatusBreakdownProps {
   period: RevenueChartPeriod
 }
 
-// Distinct, theme-friendly palette — chosen so adjacent slices stay readable in
-// both light and dark mode. Tailwind's `[hsl(...)]` arbitrary values can't be
-// referenced from recharts, so we keep the colors inline.
+// Inline because recharts can't reference Tailwind's arbitrary `[hsl(...)]` values.
 const STATUS_COLOR: Record<OrderStatusForBreakdown, string> = {
   PENDING: '#9ca3af', // gray-400
   PAID: '#3b82f6', // blue-500
@@ -77,8 +75,7 @@ export function OrderStatusBreakdown({ period }: OrderStatusBreakdownProps) {
     enabled: accessToken !== null,
   })
 
-  // Only non-zero slices show on the donut — zero-count statuses still appear
-  // in the legend so the customer can see the full set of buckets.
+  // Donut hides empty slices; the legend still shows the full bucket list.
   const allRows = (data ?? []).map((row) => ({
     ...row,
     label: t(STATUS_LABEL_KEY[row.status]),

--- a/apps/web/src/app/[locale]/admin/customers/[id]/_components/__tests__/customer-detail.test.tsx
+++ b/apps/web/src/app/[locale]/admin/customers/[id]/_components/__tests__/customer-detail.test.tsx
@@ -91,7 +91,6 @@ describe('CustomerDetail', () => {
 
     await waitFor(() => expect(screen.getByText('jane@example.com')).toBeInTheDocument())
     expect(screen.getByText('$245.50')).toBeInTheDocument()
-    // Total orders rendered as just the number — assert via the dd element class
     expect(screen.getByText('2')).toBeInTheDocument()
   })
 

--- a/apps/web/src/app/[locale]/admin/customers/_components/customers-table.tsx
+++ b/apps/web/src/app/[locale]/admin/customers/_components/customers-table.tsx
@@ -27,8 +27,6 @@ export function CustomersTable() {
   const [searchInput, setSearchInput] = useState('')
   const [search, setSearch] = useState('')
 
-  // Debounce the search term so we don't fire a request on every keystroke.
-  // 300ms is the same window used by other admin search inputs in this app.
   useEffect(() => {
     const handle = window.setTimeout(() => {
       setSearch(searchInput)

--- a/apps/web/src/app/[locale]/admin/discounts/_components/__tests__/discounts-table.test.tsx
+++ b/apps/web/src/app/[locale]/admin/discounts/_components/__tests__/discounts-table.test.tsx
@@ -31,7 +31,6 @@ vi.mock('@/store/auth.store', () => ({
     selector({ accessToken: 'test-token' }),
 }))
 
-// confirm() is used for delete confirmation — auto-accept in tests
 const originalConfirm = global.confirm
 
 function buildDiscount(
@@ -168,8 +167,6 @@ describe('DiscountsTable', () => {
     await userEvent.click(screen.getByRole('button', { name: /Delete code WELCOME10/i }))
 
     const dialog = await screen.findByRole('dialog')
-    // The destructive primary button inside the dialog is labelled "Delete"
-    // (the row trash button uses "Delete code …" aria-label).
     const confirmButton = within(dialog).getByRole('button', { name: /^delete$/i })
     await userEvent.click(confirmButton)
 

--- a/apps/web/src/app/[locale]/admin/discounts/_components/discounts-table.tsx
+++ b/apps/web/src/app/[locale]/admin/discounts/_components/discounts-table.tsx
@@ -94,8 +94,6 @@ export function DiscountsTable() {
     if (!discountToDelete) return
     deleteMutation.mutate(discountToDelete.id, {
       onSuccess: () => setDiscountToDelete(null),
-      // On error, keep the dialog open so the toast doesn't get lost and the
-      // admin can decide to cancel or retry.
     })
   }
 

--- a/apps/web/src/app/[locale]/admin/inventory/_components/__tests__/inventory-table.test.tsx
+++ b/apps/web/src/app/[locale]/admin/inventory/_components/__tests__/inventory-table.test.tsx
@@ -89,9 +89,7 @@ describe('InventoryTable', () => {
     render(<InventoryTable />)
 
     await waitFor(() => expect(screen.getByText('Silver Ring')).toBeInTheDocument())
-    // The badge appears in a TableCell; the "Low stock only" Label appears in
-    // the filter card. Disambiguate by counting all matches: 2 when low stock,
-    // 1 (just the filter label) when not.
+    // 2 matches when the row also renders the badge; 1 when only the filter label remains.
     expect(screen.getAllByText(/Low stock/i)).toHaveLength(2)
     expect(screen.getByRole('button', { name: /Edit stock for Silver Ring/i })).toHaveTextContent(
       '1',
@@ -107,7 +105,6 @@ describe('InventoryTable', () => {
     render(<InventoryTable />)
 
     await waitFor(() => expect(screen.getByText('Silver Ring')).toBeInTheDocument())
-    // Only the filter Label remains — no badge in the row.
     expect(screen.getAllByText(/Low stock/i)).toHaveLength(1)
   })
 

--- a/apps/web/src/app/[locale]/admin/layout.tsx
+++ b/apps/web/src/app/[locale]/admin/layout.tsx
@@ -7,15 +7,6 @@ interface AdminLayoutProps {
   children: ReactNode
 }
 
-/**
- * Admin section layout — wraps all /admin/* pages.
- * Renders a fixed sidebar + main content area.
- * AdminAuthGuard (client component) enforces ADMIN role on the client;
- * it redirects to / if the user is not authenticated or not an ADMIN.
- *
- * AdminHeaderHelp floats a `?` help button (and registers the `?` keyboard
- * shortcut) per active route — see `lib/admin-help/path-to-help-slug.ts`.
- */
 export default function AdminLayout({ children }: AdminLayoutProps) {
   return (
     <AdminAuthGuard>

--- a/apps/web/src/app/[locale]/admin/loading.tsx
+++ b/apps/web/src/app/[locale]/admin/loading.tsx
@@ -1,44 +1,29 @@
-// Mirrors AdminDashboardPage layout to prevent CLS:
-//   h1.text-2xl.font-semibold.mb-6
-//   StatsCards: ul.grid.gap-4.sm:grid-cols-2.lg:grid-cols-3 — 3 Cards
-//     Card: CardHeader(flex-row justify-between pb-2: title text-sm + icon size-4)
-//           + CardContent(text-2xl font-bold)
-//   div.mt-6 > RevenueChart: Card {
-//     CardHeader(flex-row justify-between: title text-base + 4 period buttons text-xs)
-//     CardContent: dl.grid-cols-3(3 cells: dt text-xs + dd text-lg) + chart h-48
-//   }
+// Mirrors AdminDashboardPage layout to prevent CLS — any change to that page
+// must be reflected here in the same shape, or the cards/chart will jump on
+// mount. The blocks correspond 1:1 to the real components.
 export default function AdminLoading() {
   return (
     <div className="flex flex-col">
-      {/* h1.mb-6.text-2xl.font-semibold */}
       <div className="mb-6 h-8 w-48 animate-pulse rounded bg-skeleton-base" />
 
-      {/* StatsCards: ul.grid.gap-4.sm:grid-cols-2.lg:grid-cols-3 — 3 cards */}
       <ul role="list" className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
         {Array.from({ length: 3 }).map((_, cardIndex) => (
           <li key={cardIndex}>
-            {/* Card = rounded-lg border bg-card — matches Shadcn Card */}
             <div className="rounded-lg border border-border bg-card p-6">
-              {/* CardHeader: flex-row items-center justify-between pb-2 */}
               <div className="mb-2 flex items-center justify-between pb-2">
                 <div className="h-4 w-24 animate-pulse rounded bg-skeleton-base" />
                 <div className="size-4 animate-pulse rounded bg-skeleton-base" />
               </div>
-              {/* CardContent: text-2xl.font-bold */}
               <div className="h-8 w-16 animate-pulse rounded bg-skeleton-base" />
             </div>
           </li>
         ))}
       </ul>
 
-      {/* div.mt-6 > RevenueChart Card */}
       <div className="mt-6">
         <div className="rounded-lg border border-border bg-card p-6">
-          {/* CardHeader: flex-row items-center justify-between gap-4 pb-2 */}
           <div className="mb-2 flex items-center justify-between gap-4 pb-2">
-            {/* title text-base.font-semibold */}
             <div className="h-5 w-20 animate-pulse rounded bg-skeleton-base" />
-            {/* 4 period selector buttons text-xs (≈ h-7 w-12 each) */}
             <div className="flex gap-1">
               {Array.from({ length: 4 }).map((_, buttonIndex) => (
                 <div
@@ -49,8 +34,6 @@ export default function AdminLoading() {
             </div>
           </div>
 
-          {/* CardContent */}
-          {/* Summary dl.grid-cols-3: each cell has dt text-xs + dd text-lg */}
           <div className="mb-4 grid grid-cols-3 gap-4">
             {Array.from({ length: 3 }).map((_, summaryIndex) => (
               <div key={summaryIndex} className="flex flex-col gap-1">
@@ -60,7 +43,6 @@ export default function AdminLoading() {
             ))}
           </div>
 
-          {/* Chart area: ResponsiveContainer h-48 */}
           <div className="h-48 animate-pulse rounded-md bg-skeleton-base" />
         </div>
       </div>

--- a/apps/web/src/app/[locale]/admin/orders/[id]/_components/__tests__/admin-order-detail.test.tsx
+++ b/apps/web/src/app/[locale]/admin/orders/[id]/_components/__tests__/admin-order-detail.test.tsx
@@ -185,7 +185,6 @@ describe('AdminOrderDetail — rendering', () => {
 
   it('renders status history timeline entries', async () => {
     render(<AdminOrderDetail orderId="clorder1234567890" />)
-    // Both history entries should be rendered as badges in the timeline
     const paidBadges = await screen.findAllByText('Paid')
     expect(paidBadges.length).toBeGreaterThanOrEqual(1)
   })
@@ -210,7 +209,6 @@ describe('AdminOrderDetail — status update', () => {
 
   it('renders allowed next status buttons for PAID order', async () => {
     render(<AdminOrderDetail orderId="clorder1234567890" />)
-    // PAID → PROCESSING, CANCELLED — button text is "Set to {status}"
     expect(await screen.findByRole('button', { name: /set to processing/i })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: /set to cancelled/i })).toBeInTheDocument()
   })
@@ -249,15 +247,14 @@ describe('AdminOrderDetail — tracking', () => {
     render(<AdminOrderDetail orderId="clorder1234567890" />)
     const trackingInput = await screen.findByLabelText('Tracking number')
     expect(trackingInput).toBeInTheDocument()
-    // The label-purchase section also has a "Carrier" label — scope to the
-    // tracking <section> to assert this specifically.
+    // LabelPurchaseSection has its own "Carrier" label — scope the assertion.
     const trackingSection = trackingInput.closest('section') as HTMLElement
     expect(within(trackingSection).getByLabelText('Carrier')).toBeInTheDocument()
   })
 
   it('submit button is disabled when tracking number is empty', async () => {
     render(<AdminOrderDetail orderId="clorder1234567890" />)
-    await screen.findByLabelText('Tracking number') // wait for data
+    await screen.findByLabelText('Tracking number')
     const saveButton = screen.getByRole('button', { name: 'Save tracking' })
     expect(saveButton).toBeDisabled()
   })
@@ -274,9 +271,7 @@ describe('AdminOrderDetail — tracking', () => {
     render(<AdminOrderDetail orderId="clorder1234567890" />)
     const trackingInput = await screen.findByLabelText('Tracking number')
 
-    // Scope to the tracking section — the LabelPurchaseSection has its own
-    // carrier select with the same label text, so an unscoped getByRole would
-    // match both.
+    // LabelPurchaseSection has a carrier select with the same label; scope.
     const trackingSection = trackingInput.closest('section') as HTMLElement
     const trackingCarrierTrigger = within(trackingSection).getByRole('combobox')
 

--- a/apps/web/src/app/[locale]/admin/orders/[id]/_components/__tests__/label-purchase-section.test.tsx
+++ b/apps/web/src/app/[locale]/admin/orders/[id]/_components/__tests__/label-purchase-section.test.tsx
@@ -111,14 +111,12 @@ describe('LabelPurchaseSection — render gating', () => {
   })
 })
 
-// UI side of the production dry-run guard
 describe('LabelPurchaseSection — dry-run purchase block', () => {
   it('disables the Purchase button and shows the warning banner in dry-run mode', async () => {
     mockFetchShippingStatus.mockResolvedValue({ isLiveMode: false })
 
     render(<LabelPurchaseSection order={baseOrder} />)
 
-    // Warning banner appears only after the query resolves — wait for it
     const alert = await screen.findByRole('alert')
     expect(alert).toHaveTextContent(/EasyPost is in dry-run mode/i)
     expect(screen.getByRole('button', { name: 'Purchase label' })).toBeDisabled()
@@ -130,7 +128,6 @@ describe('LabelPurchaseSection — dry-run purchase block', () => {
 
     render(<LabelPurchaseSection order={baseOrder} />)
 
-    // Wait for the disabled state to propagate before clicking
     await screen.findByRole('alert')
     const button = screen.getByRole('button', { name: 'Purchase label' })
     await user.click(button)
@@ -141,7 +138,6 @@ describe('LabelPurchaseSection — dry-run purchase block', () => {
   it('enables the Purchase button and hides the warning banner in live mode', async () => {
     render(<LabelPurchaseSection order={baseOrder} />)
 
-    // Wait for the query to settle (Live badge appears once data arrives)
     await screen.findByText('Live')
     const button = screen.getByRole('button', { name: 'Purchase label' })
     expect(button).not.toBeDisabled()

--- a/apps/web/src/app/[locale]/admin/orders/[id]/_components/admin-order-detail.tsx
+++ b/apps/web/src/app/[locale]/admin/orders/[id]/_components/admin-order-detail.tsx
@@ -45,7 +45,7 @@ interface AdminOrderDetailProps {
   orderId: string
 }
 
-// Mirrors the backend state machine whitelist
+// Mirrors the backend state machine whitelist.
 const ALLOWED_TRANSITIONS: Record<OrderStatus, OrderStatus[]> = {
   PENDING: ['PAID', 'CANCELLED'],
   PAID: ['PROCESSING', 'CANCELLED'],
@@ -479,9 +479,6 @@ export function AdminOrderDetail({ orderId }: AdminOrderDetailProps) {
     },
   })
 
-  // Status transitions with customer-visible side effects (email / loyalty
-  // credit / terminal CANCELLED) go through ConfirmDialog. Reversible
-  // silent-to-customer transitions fire immediately.
   function handleStatusChange(newStatus: OrderStatus) {
     if (requiresStatusConfirmation(newStatus)) {
       setPendingStatus(newStatus)
@@ -558,7 +555,6 @@ export function AdminOrderDetail({ orderId }: AdminOrderDetailProps) {
             isUpdating={trackingMutation.isPending}
           />
 
-          {/* Refund — only for orders with a successful or partially refunded payment. */}
           {order.payment &&
             (order.payment.status === 'SUCCEEDED' ||
               order.payment.status === 'PARTIALLY_REFUNDED') && (
@@ -580,8 +576,6 @@ export function AdminOrderDetail({ orderId }: AdminOrderDetailProps) {
             onClose={() => setIsRefundModalOpen(false)}
             orderId={order.id}
             orderTotal={Number(order.total)}
-            // refundAmount comes through as a string after JSON serialization
-            // when populated; Number() handles both null and string safely.
             alreadyRefunded={order.refundAmount != null ? Number(order.refundAmount) : 0}
           />
         </>

--- a/apps/web/src/app/[locale]/admin/orders/[id]/_components/label-purchase-section.tsx
+++ b/apps/web/src/app/[locale]/admin/orders/[id]/_components/label-purchase-section.tsx
@@ -27,9 +27,7 @@ import { useAuthStore } from '@/store/auth.store'
 
 const CARRIERS: ShippingCarrier[] = ['USPS', 'FedEx', 'UPS', 'DHL']
 
-// Threshold above which insurance is offered — matches docs/08 #4 risk note:
-// shipping insurance becomes meaningful for high-value jewelry. We default
-// the insurance amount to the full order total.
+// Threshold above which insurance is offered — see docs/08 §4 risk note.
 const INSURANCE_OFFER_THRESHOLD_CENTS = 10_000
 
 interface LabelPurchaseSectionProps {
@@ -56,11 +54,8 @@ export function LabelPurchaseSection({ order }: LabelPurchaseSectionProps) {
     staleTime: 5 * 60 * 1000,
   })
 
-  // Block purchase entirely when EasyPost is in dry-run mode. The mock client
-  // fabricates MOCK… tracking numbers that would otherwise reach real customers
-  // via the shipping email. Backend enforces the same guard in production
-  // (returns 503) — this is the user-visible side of the safety net.
-  // While the status is still loading we treat it as "not live" — fail-closed.
+  // Backend returns 503 when EasyPost is in dry-run mode (mock tracking numbers
+  // would otherwise reach customers); we fail-closed while loading.
   const isLiveMode = shippingStatusQuery.data?.isLiveMode === true
   const isDryRunBlocked = shippingStatusQuery.data !== undefined && !isLiveMode
 
@@ -84,9 +79,6 @@ export function LabelPurchaseSection({ order }: LabelPurchaseSectionProps) {
     },
   })
 
-  // Hide the whole panel for terminal/cancelled orders. There's nothing the
-  // admin can act on, and the existing tracking section already shows the
-  // last known label info on a refunded/delivered order if it exists.
   if (!canPurchase && !alreadyPurchased) return null
 
   return (

--- a/apps/web/src/app/[locale]/admin/orders/[id]/_components/refund-order-modal.tsx
+++ b/apps/web/src/app/[locale]/admin/orders/[id]/_components/refund-order-modal.tsx
@@ -42,7 +42,6 @@ interface RefundOrderModalProps {
   onClose: () => void
   orderId: string
   orderTotal: number
-  /** Amount already refunded on this order (0 for first-time refund). */
   alreadyRefunded: number
 }
 
@@ -71,7 +70,7 @@ export function RefundOrderModal({
   )
   const remainingFormatted = remainingRefundable.toFixed(2)
 
-  // amount is optional — empty string + transform → undefined means "full refund"
+  // Empty string → undefined means "full refund".
   const refundFormSchema = useMemo(
     () =>
       z.object({

--- a/apps/web/src/app/[locale]/admin/orders/_components/__tests__/admin-orders-table.test.tsx
+++ b/apps/web/src/app/[locale]/admin/orders/_components/__tests__/admin-orders-table.test.tsx
@@ -150,7 +150,6 @@ describe('AdminOrdersTable — rendering', () => {
 
     render(<AdminOrdersTable />)
 
-    // total 7300 cents → $7300.00
     expect(await screen.findByText('$7300.00')).toBeInTheDocument()
   })
 
@@ -192,7 +191,6 @@ describe('AdminOrdersTable — status transitions', () => {
 
     render(<AdminOrdersTable />)
 
-    // PENDING has transitions → rendered as a button trigger
     const statusButton = await screen.findByRole('button', {
       name: /change status for order 00000001/i,
     })
@@ -210,7 +208,6 @@ describe('AdminOrdersTable — status transitions', () => {
 
     await screen.findByText('REFUNDED')
 
-    // No dropdown trigger button for terminal state
     expect(
       screen.queryByRole('button', { name: /change status for order/i }),
     ).not.toBeInTheDocument()
@@ -231,7 +228,7 @@ describe('AdminOrdersTable — status transitions', () => {
     const paidOption = await screen.findByRole('menuitem', { name: /paid/i })
     await user.click(paidOption)
 
-    // PENDING → PAID has no customer side effects, so it must not gate on a dialog
+    // PENDING → PAID is silent-to-customer — must skip the confirm dialog.
     expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
     await waitFor(() => {
       expect(mockUpdateAdminOrderStatus).toHaveBeenCalledWith(

--- a/apps/web/src/app/[locale]/admin/orders/_components/admin-orders-table.tsx
+++ b/apps/web/src/app/[locale]/admin/orders/_components/admin-orders-table.tsx
@@ -41,7 +41,7 @@ import { ApiError } from '@/lib/api/client'
 import type { AdminOrdersQueryParams } from '@/lib/api/orders'
 import { getStatusConfirmCopy, requiresStatusConfirmation } from '../_lib/status-confirm'
 
-// Transitions whitelist mirrors the backend state machine
+// Mirrors the backend state machine.
 const ALLOWED_TRANSITIONS: Record<OrderStatus, OrderStatus[]> = {
   PENDING: ['PAID', 'CANCELLED'],
   PAID: ['PROCESSING', 'CANCELLED'],
@@ -98,7 +98,6 @@ export function AdminOrdersTable() {
     if (!accessToken) return
     setIsExporting(true)
     try {
-      // Mirror the active status filter so the export matches what's visible.
       await downloadAdminOrdersCsv(
         statusFilter !== 'ALL' ? { status: statusFilter } : {},
         accessToken,
@@ -138,8 +137,6 @@ export function AdminOrdersTable() {
     },
   })
 
-  // Same gate as the order detail page: side-effect transitions confirm,
-  // others fire instantly.
   function handleStatusChange(orderId: string, newStatus: OrderStatus) {
     if (requiresStatusConfirmation(newStatus)) {
       setPendingTransition({ orderId, newStatus })

--- a/apps/web/src/app/[locale]/admin/orders/_lib/status-confirm.ts
+++ b/apps/web/src/app/[locale]/admin/orders/_lib/status-confirm.ts
@@ -1,25 +1,13 @@
 import type { OrderStatus } from '@/lib/api/orders'
 
-/**
- * Order status transitions that fire customer-visible side effects:
- *   SHIPPED   → shipping confirmation email
- *   DELIVERED → loyalty credit + delivery email
- *   CANCELLED → terminal, no undo through the UI
- *
- * Everything else (PENDING → PAID, PAID → PROCESSING) is silent-to-customer
- * and reversible, so we don't show a confirmation prompt.
- */
+// Transitions with customer-visible side effects (email / loyalty credit) or
+// no undo through the UI. Reversible silent transitions skip confirmation.
 const CONFIRM_STATUSES = new Set<OrderStatus>(['SHIPPED', 'DELIVERED', 'CANCELLED'])
 
 export function requiresStatusConfirmation(nextStatus: OrderStatus): boolean {
   return CONFIRM_STATUSES.has(nextStatus)
 }
 
-/**
- * The three i18n keys (title, description, action) for a given confirm-worthy
- * status. Caller passes the lookup result into the dialog plus `{ id }` for
- * title interpolation.
- */
 export interface StatusConfirmCopy {
   titleKey:
     | 'ordersConfirmShippedTitle'
@@ -33,7 +21,6 @@ export interface StatusConfirmCopy {
     | 'ordersConfirmShippedAction'
     | 'ordersConfirmDeliveredAction'
     | 'ordersConfirmCancelledAction'
-  /** `destructive` for CANCELLED (terminal), `default` for the others. */
   variant: 'destructive' | 'default'
 }
 

--- a/apps/web/src/app/[locale]/admin/orders/production/_components/production-table.tsx
+++ b/apps/web/src/app/[locale]/admin/orders/production/_components/production-table.tsx
@@ -33,10 +33,8 @@ import {
 
 const PRODUCTION_STATUSES: ProductionStatus[] = ['QUEUED', 'IN_PRODUCTION', 'READY_TO_SHIP']
 
-/**
- * Days between two dates, rounded toward zero so a deadline 1.5 days away
- * shows as "1 day left" (under-promise) rather than "2 days left".
- */
+// Rounded toward zero — a deadline 1.5 days away shows as "1 day left"
+// (under-promise).
 function daysUntil(deadlineIso: string): number {
   const now = Date.now()
   const deadline = new Date(deadlineIso).getTime()
@@ -158,10 +156,7 @@ function ProductionRow({ order, onUpdateStatus, onSaveNotes, isSaving }: Product
     onSaveNotes(trimmed)
   }
 
-  const mtoItemCount = order.items.filter(
-    // OrderItem.productSnapshot.title is the human-friendly label captured at order time
-    (item) => item.productSnapshot?.title,
-  ).length
+  const mtoItemCount = order.items.filter((item) => item.productSnapshot?.title).length
 
   return (
     <TableRow>

--- a/apps/web/src/app/[locale]/admin/orders/refunds/_components/admin-refunds-table.tsx
+++ b/apps/web/src/app/[locale]/admin/orders/refunds/_components/admin-refunds-table.tsx
@@ -31,25 +31,18 @@ import { REFUND_REASONS, useRefundsFilters } from './use-refunds-filters'
 const CUSTOMER_DEBOUNCE_MS = 300
 const REASON_ALL_SENTINEL = 'ALL'
 
-/**
- * Read-only ledger of every refund issued through the admin. Filters live in
- * the URL so refreshing or sharing the page preserves the view.
- *
- * The customer input is debounced locally — every keystroke shouldn't push a
- * new URL entry — but the debounce only governs the URL write. Once committed
- * to the URL, TanStack Query picks the new param up via the queryKey.
- */
+// Filters live in the URL so refreshing or sharing preserves the view; the
+// customer input is debounced before being written so each keystroke isn't a
+// new history entry.
 export function AdminRefundsTable() {
   const t = useTranslations('admin')
   const accessToken = useAuthStore((state) => state.accessToken)
   const { filters, setFilter, clearFilters, hasActiveFilters } = useRefundsFilters()
 
-  // Local mirror of the customer input so the field updates instantly while
-  // we wait the 300ms before writing to the URL.
   const [customerDraft, setCustomerDraft] = useState(filters.customer ?? '')
 
   useEffect(() => {
-    // Keep the input in sync when the URL changes externally (e.g. Clear).
+    // Sync when the URL changes externally (e.g. Clear).
     setCustomerDraft(filters.customer ?? '')
   }, [filters.customer])
 

--- a/apps/web/src/app/[locale]/admin/orders/refunds/_components/use-refunds-filters.ts
+++ b/apps/web/src/app/[locale]/admin/orders/refunds/_components/use-refunds-filters.ts
@@ -16,7 +16,7 @@ function isRefundReason(value: string): value is RefundReason {
   return (REFUND_REASONS as readonly string[]).includes(value)
 }
 
-/** URL-derived filter values + setters. Filters survive refresh + share. */
+// Filters live in the URL so they survive refresh + share.
 export function useRefundsFilters(): {
   filters: AdminRefundsQueryParams
   setFilter: (key: keyof AdminRefundsQueryParams, value: string) => void
@@ -32,7 +32,6 @@ export function useRefundsFilters(): {
     return {
       from: searchParams.get('from') ?? undefined,
       to: searchParams.get('to') ?? undefined,
-      // Guard against arbitrary URL input — only accept a known enum value.
       reason: reason && isRefundReason(reason) ? reason : undefined,
       customer: searchParams.get('customer') ?? undefined,
     }
@@ -46,7 +45,7 @@ export function useRefundsFilters(): {
       } else {
         next.set(key, value)
       }
-      // `replace` (not `push`) — filter tweaks shouldn't grow browser history.
+      // `replace` — filter tweaks shouldn't grow browser history.
       router.replace(`${pathname}?${next.toString()}`, { scroll: false })
     },
     [pathname, router, searchParams],

--- a/apps/web/src/app/[locale]/admin/products/[slug]/edit/_components/edit-product-form.tsx
+++ b/apps/web/src/app/[locale]/admin/products/[slug]/edit/_components/edit-product-form.tsx
@@ -117,7 +117,6 @@ export function EditProductForm({ categories, product }: EditProductFormProps) {
 
   const watchedTitle = watch('title')
 
-  // Auto-generate slug from title with 400ms debounce
   useEffect(() => {
     if (isSlugManuallyEdited || !watchedTitle) return
 
@@ -136,7 +135,6 @@ export function EditProductForm({ categories, product }: EditProductFormProps) {
     mutationFn: (formValues: CreateProductFormValues) => {
       const payload = {
         ...formValues,
-        // Convert empty strings to undefined for optional fields
         sku: formValues.sku || undefined,
         material: formValues.material || undefined,
       }

--- a/apps/web/src/app/[locale]/admin/products/_components/__tests__/admin-products-table.test.tsx
+++ b/apps/web/src/app/[locale]/admin/products/_components/__tests__/admin-products-table.test.tsx
@@ -96,7 +96,6 @@ const twoProducts = {
 beforeEach(() => {
   vi.clearAllMocks()
   mockFetchAdminProducts.mockResolvedValue(twoProducts as never)
-  // Suppress unused-import warnings — these are mocked for table internals.
   void mockUpdateProductStatus
   void mockDeleteAdminProduct
 })
@@ -113,7 +112,7 @@ describe('AdminProductsTable — bulk selection', () => {
     render(<AdminProductsTable />)
 
     await screen.findByText('Ring A')
-    // 1 header + 2 rows = 3 total
+    // 1 header checkbox + 2 row checkboxes.
     expect(screen.getAllByRole('checkbox')).toHaveLength(3)
   })
 
@@ -186,7 +185,6 @@ describe('AdminProductsTable — bulk actions', () => {
     await user.click(screen.getByRole('button', { name: /^publish$/i }))
 
     const dialog = await screen.findByRole('dialog')
-    // Confirm button inside the dialog uses the "Publish" action label
     await user.click(within(dialog).getByRole('button', { name: /^publish$/i }))
 
     await waitFor(() => {

--- a/apps/web/src/app/[locale]/admin/products/_components/__tests__/product-image-upload.test.tsx
+++ b/apps/web/src/app/[locale]/admin/products/_components/__tests__/product-image-upload.test.tsx
@@ -24,7 +24,6 @@ vi.mock('@/store/auth.store', () => ({
   useAuthStore: vi.fn(),
 }))
 
-// jsdom does not implement URL.createObjectURL
 window.URL.createObjectURL = vi.fn(() => 'blob:mock-preview-url')
 window.URL.revokeObjectURL = vi.fn()
 

--- a/apps/web/src/app/[locale]/admin/products/_components/admin-products-table.tsx
+++ b/apps/web/src/app/[locale]/admin/products/_components/admin-products-table.tsx
@@ -103,8 +103,6 @@ export function AdminProductsTable() {
   const [productToDelete, setProductToDelete] = useState<ProductTableRow | null>(null)
   const [isExporting, setIsExporting] = useState(false)
   const [selectedIds, setSelectedIds] = useState<Set<string>>(() => new Set())
-  // One field for all three bulk-confirm dialogs (publish/draft/delete) — the
-  // value drives both the visibility and the action to fire on confirm.
   const [pendingBulkAction, setPendingBulkAction] = useState<BulkProductAction | null>(null)
 
   async function handleExportCsv() {
@@ -136,7 +134,6 @@ export function AdminProductsTable() {
     })
   }
 
-  // Debounce search to avoid excessive API calls
   const handleSearchChange = (value: string) => {
     setSearchQuery(value)
     clearTimeout((handleSearchChange as { timer?: ReturnType<typeof setTimeout> }).timer)
@@ -243,8 +240,7 @@ export function AdminProductsTable() {
     [data?.data],
   )
 
-  // Selection lives outside the URL: stale ids across page/filter changes are
-  // confusing, so we reset on any queryParams shift.
+  // Reset selection on any queryParams shift — stale ids across pages confuse.
   useEffect(() => {
     setSelectedIds(new Set())
   }, [debouncedSearch, statusFilter, sortBy, sortOrder, currentPage])
@@ -309,9 +305,8 @@ export function AdminProductsTable() {
     },
   })
 
-  // Every bulk action now confirms — publish/draft used to skip the dialog,
-  // but a 50-product misclick on Publish is silent and irreversible enough to
-  // warrant the same speed bump as Delete.
+  // Every bulk action confirms — a 50-product misclick on Publish is silent
+  // and effectively irreversible.
   function handleBulkActionClick(action: BulkProductAction) {
     if (selectedIds.size === 0) return
     setPendingBulkAction(action)

--- a/apps/web/src/app/[locale]/admin/products/_components/product-image-upload.tsx
+++ b/apps/web/src/app/[locale]/admin/products/_components/product-image-upload.tsx
@@ -147,7 +147,6 @@ export function ProductImageUpload({
 
       setUploadItems((previousItems) => [...previousItems, ...newItems])
 
-      // Start uploading valid files immediately
       newItems
         .filter((newItem) => newItem.status === 'pending')
         .forEach((newItem) => void uploadFile(newItem))
@@ -159,7 +158,6 @@ export function ProductImageUpload({
     (event: React.ChangeEvent<HTMLInputElement>) => {
       const files = Array.from(event.target.files ?? [])
       if (files.length > 0) addFiles(files)
-      // Reset input so same file can be re-selected after removal
       event.target.value = ''
     },
     [addFiles],

--- a/apps/web/src/app/[locale]/admin/products/_lib/create-product-schema.ts
+++ b/apps/web/src/app/[locale]/admin/products/_lib/create-product-schema.ts
@@ -10,7 +10,7 @@ export const createProductSchema = z
       .number({ message: 'Price must be a number' })
       .positive('Price must be positive')
       .multipleOf(0.01, 'Price can have at most 2 decimal places'),
-    // Handmade business model: stock is binary, 0 (made on order) or 1 (one piece ready to ship).
+    // Binary: 0 (made on order) or 1 (one piece ready to ship).
     stock: z
       .number({ message: 'Stock must be a number' })
       .int('Stock must be a whole number')
@@ -31,7 +31,6 @@ export const createProductSchema = z
     stockType: z.enum(STOCK_TYPES).default('IN_STOCK'),
     // Required when stock = 0 — see .superRefine below.
     productionDays: z.number().int().min(0).max(365).optional(),
-    // Dimensions — all optional, stored in metric
     lengthCm: z.number().positive().max(500).optional(),
     widthCm: z.number().positive().max(500).optional(),
     heightCm: z.number().positive().max(500).optional(),
@@ -40,9 +39,8 @@ export const createProductSchema = z
     beadSizeMm: z.number().positive().max(100).optional(),
   })
   .superRefine((value, ctx) => {
-    // Handmade products are always orderable, but if there's no piece ready
-    // (stock=0) the master must commit to a lead time. 0 days + 0 stock is a
-    // contradiction we never want to ship.
+    // 0 days + 0 stock is contradictory — when nothing is ready, the master
+    // must commit to a lead time so the customer knows the wait.
     if (value.stock === 0 && (value.productionDays === undefined || value.productionDays < 1)) {
       ctx.addIssue({
         code: 'custom',

--- a/apps/web/src/app/[locale]/admin/products/new/_components/__tests__/create-product-form.test.tsx
+++ b/apps/web/src/app/[locale]/admin/products/new/_components/__tests__/create-product-form.test.tsx
@@ -31,7 +31,6 @@ vi.mock('@/i18n/navigation', () => ({
   ),
 }))
 
-// Mock ProductImageUpload to isolate form logic from upload complexity
 vi.mock('../../../_components/product-image-upload', () => ({
   ProductImageUpload: ({
     onImagesChange,
@@ -66,7 +65,7 @@ beforeEach(() => {
   mockUseAuthStore.mockImplementation((selector) =>
     selector({ accessToken: 'mock-token' } as Parameters<typeof selector>[0]),
   )
-  // jsdom does not implement Pointer Events — required by Radix UI Select
+  // jsdom-missing APIs required by Radix UI Select.
   window.HTMLElement.prototype.hasPointerCapture = vi.fn()
   window.HTMLElement.prototype.setPointerCapture = vi.fn()
   window.HTMLElement.prototype.releasePointerCapture = vi.fn()
@@ -74,7 +73,6 @@ beforeEach(() => {
 })
 
 afterEach(() => {
-  // Ensure fake timers are always restored so they don't leak into other tests
   vi.useRealTimers()
 })
 
@@ -98,7 +96,6 @@ describe('CreateProductForm — rendering', () => {
   it('renders category options from props', async () => {
     render(<CreateProductForm categories={sampleCategories} />)
 
-    // Open the category select — queried by aria-label on SelectTrigger
     const categoryTrigger = screen.getByRole('combobox', { name: /category/i })
     await userEvent.click(categoryTrigger)
 
@@ -120,7 +117,6 @@ describe('CreateProductForm — slug auto-generation', () => {
 
     await userEvent.type(screen.getByPlaceholderText(/northern lights bracelet/i), 'Silver Ring')
 
-    // waitFor polls until the 400ms debounce fires naturally
     await waitFor(
       () => {
         const slugInput = screen.getByRole('textbox', { name: /url slug/i })
@@ -139,7 +135,6 @@ describe('CreateProductForm — slug auto-generation', () => {
 
     await userEvent.type(screen.getByPlaceholderText(/northern lights bracelet/i), 'Silver Ring')
 
-    // Wait long enough for debounce to fire — slug must remain unchanged
     await waitFor(
       () => {
         expect((slugInput as HTMLInputElement).value).toBe('my-custom-slug')
@@ -175,7 +170,6 @@ describe('CreateProductForm — submission', () => {
 
     await userEvent.type(screen.getByPlaceholderText(/northern lights bracelet/i), 'Silver Ring')
 
-    // Wait for slug debounce to fire before filling other fields
     await waitFor(
       () => {
         const slugInput = screen.getByRole('textbox', { name: /url slug/i })
@@ -191,11 +185,9 @@ describe('CreateProductForm — submission', () => {
     await userEvent.type(screen.getByRole('spinbutton', { name: /price \(usd\)/i }), '49.99')
     await userEvent.click(screen.getByRole('button', { name: /in stock \(1 piece ready\)/i }))
 
-    // Select category
     await userEvent.click(screen.getByRole('combobox', { name: /category/i }))
     await userEvent.click(await screen.findByRole('option', { name: 'Bracelets' }))
 
-    // Add image via mock
     await userEvent.click(screen.getByTestId('mock-image-upload'))
 
     await userEvent.click(screen.getByRole('button', { name: /create product/i }))

--- a/apps/web/src/app/[locale]/admin/products/new/_components/create-product-form.tsx
+++ b/apps/web/src/app/[locale]/admin/products/new/_components/create-product-form.tsx
@@ -95,7 +95,6 @@ export function CreateProductForm({ categories }: CreateProductFormProps) {
 
   const watchedTitle = watch('title')
 
-  // Auto-generate slug from title with 400ms debounce
   useEffect(() => {
     if (isSlugManuallyEdited || !watchedTitle) return
 
@@ -114,7 +113,6 @@ export function CreateProductForm({ categories }: CreateProductFormProps) {
     mutationFn: (formValues: CreateProductFormValues) => {
       const payload = {
         ...formValues,
-        // Convert empty strings to undefined for optional fields
         sku: formValues.sku || undefined,
         material: formValues.material || undefined,
       }

--- a/apps/web/src/app/[locale]/admin/products/new/page.tsx
+++ b/apps/web/src/app/[locale]/admin/products/new/page.tsx
@@ -8,7 +8,6 @@ export const metadata: Metadata = {
 }
 
 export default async function AdminNewProductPage() {
-  // Fetch categories server-side — no loading state in form, instant render
   const categories = await fetchCategories()
 
   return (

--- a/apps/web/src/app/[locale]/admin/settings/_components/__tests__/settings-form.test.tsx
+++ b/apps/web/src/app/[locale]/admin/settings/_components/__tests__/settings-form.test.tsx
@@ -101,14 +101,13 @@ describe('SettingsForm', () => {
     await userEvent.clear(storeNameInput)
     await userEvent.type(storeNameInput, 'New Name')
 
-    // Each section has its own Save button — General is the first
+    // Each section has its own Save — General is the first.
     const [firstSaveButton] = screen.getAllByRole('button', { name: /Save changes/i })
     if (!firstSaveButton) throw new Error('Expected at least one Save button to render')
     await userEvent.click(firstSaveButton)
 
     await waitFor(() => expect(updateAdminSiteSettingsMock).toHaveBeenCalled())
     const [payload] = updateAdminSiteSettingsMock.mock.calls[0]!
-    // General section only — no shipping or social fields
     expect(payload).toMatchObject({ storeName: 'New Name' })
     expect(payload).not.toHaveProperty('estimatedDeliveryMinDays')
     expect(payload).not.toHaveProperty('instagramUrl')


### PR DESCRIPTION
## Why

<!-- What problem does this PR solve? Link to the issue. -->

Closes #

## What changed

<!-- List the key changes. Be specific. -->

-

## How to test

<!-- Steps to verify the change works correctly. -->

1.

## Checklist

- [ ] No `any` types in TypeScript
- [ ] `pnpm lint` passes
- [ ] `pnpm build` passes locally
- [ ] Self-reviewed the diff before opening PR
- [ ] QA: affected `docs/qa/**.md` test cases updated (or N/A — purely internal change)
- [ ] Admin help: if a touched admin form added/removed/renamed any field, the matching `docs/admin-help/**.md` is updated in the same PR (or N/A)
