### PR TITLE
chore: Sentry tags on admin mutations (orderId/productId + action con…

### DIFF
--- a/apps/api/src/orders/orders-refunds.service.ts
+++ b/apps/api/src/orders/orders-refunds.service.ts
@@ -1,5 +1,6 @@
 import { BadRequestException, Injectable, Logger, NotFoundException } from '@nestjs/common'
 import { OrderStatus, PaymentStatus, Prisma } from '@prisma/client'
+import * as Sentry from '@sentry/nestjs'
 import { Decimal } from '@prisma/client/runtime/library'
 import { AnalyticsService } from '../analytics/analytics.service'
 import { EmailService } from '../email/email.service'
@@ -26,6 +27,18 @@ export class OrdersRefundsService {
   // `charge.refunded` webhook is idempotent because payment.status is already
   // REFUNDED / PARTIALLY_REFUNDED by the time it fires.
   async refundOrder(orderId: string, refundOrderDto: RefundOrderDto) {
+    Sentry.setContext('order', {
+      orderId,
+      amount: refundOrderDto.amount ?? 'full-remaining',
+      reason: refundOrderDto.reason,
+    })
+    Sentry.addBreadcrumb({
+      category: 'orders.refund',
+      message: `refundOrder ${orderId}`,
+      level: 'info',
+      data: { orderId, reason: refundOrderDto.reason },
+    })
+
     const order = await this.prismaService.order.findUnique({
       where: { id: orderId },
       include: { payment: true },

--- a/apps/api/src/orders/orders.service.ts
+++ b/apps/api/src/orders/orders.service.ts
@@ -1,5 +1,6 @@
 import { BadRequestException, Injectable, Logger, NotFoundException } from '@nestjs/common'
 import { OrderStatus, Prisma } from '@prisma/client'
+import * as Sentry from '@sentry/nestjs'
 import { InputJsonValue } from '@prisma/client/runtime/library'
 import { buildCsvDocument } from '../common/csv/csv-formatter'
 import { paginate } from '../common/pagination/paginate'
@@ -256,6 +257,18 @@ export class OrdersService {
 
   async updateStatus(orderId: string, updateOrderStatusDto: UpdateOrderStatusDto) {
     const order = await this.findOneById(orderId)
+
+    Sentry.setContext('order', {
+      orderId,
+      fromStatus: order.status,
+      toStatus: updateOrderStatusDto.status,
+    })
+    Sentry.addBreadcrumb({
+      category: 'orders.status',
+      message: `updateStatus ${orderId} ${order.status} → ${updateOrderStatusDto.status}`,
+      level: 'info',
+      data: { orderId, fromStatus: order.status, toStatus: updateOrderStatusDto.status },
+    })
 
     if (!isValidOrderStatusTransition(order.status, updateOrderStatusDto.status)) {
       throw new BadRequestException(

--- a/apps/web/src/app/[locale]/admin/orders/[id]/_components/admin-order-detail.tsx
+++ b/apps/web/src/app/[locale]/admin/orders/[id]/_components/admin-order-detail.tsx
@@ -17,6 +17,7 @@ import {
   type UpdateOrderTrackingPayload,
 } from '@/lib/api/orders'
 import { ApiError } from '@/lib/api/client'
+import { captureAdminError } from '@/lib/sentry/capture-admin-error'
 import { getStatusConfirmCopy, requiresStatusConfirmation } from '../../_lib/status-confirm'
 import { CustomerInfoCard } from './customer-info-card'
 import { LabelPurchaseSection } from './label-purchase-section'
@@ -54,7 +55,12 @@ export function AdminOrderDetail({ orderId }: AdminOrderDetailProps) {
       toast.success(t('ordersStatusUpdateSuccess', { id: orderId.slice(-8) }))
       setPendingStatus(null)
     },
-    onError: (error) => {
+    onError: (error, newStatus) => {
+      captureAdminError(error, {
+        action: 'orders.updateStatus',
+        orderId,
+        newStatus,
+      })
       const message = error instanceof ApiError ? error.message : t('ordersStatusUpdateError')
       toast.error(message)
     },
@@ -78,7 +84,12 @@ export function AdminOrderDetail({ orderId }: AdminOrderDetailProps) {
       void queryClient.invalidateQueries({ queryKey: ['admin', 'orders'] })
       toast.success(t('orderDetailTrackingSaveSuccess'))
     },
-    onError: (error) => {
+    onError: (error, payload) => {
+      captureAdminError(error, {
+        action: 'orders.updateTracking',
+        orderId,
+        shippingCarrier: payload.shippingCarrier,
+      })
       const message = error instanceof ApiError ? error.message : t('orderDetailTrackingSaveError')
       toast.error(message)
     },

--- a/apps/web/src/app/[locale]/admin/orders/[id]/_components/refund-order-modal.tsx
+++ b/apps/web/src/app/[locale]/admin/orders/[id]/_components/refund-order-modal.tsx
@@ -36,6 +36,7 @@ import { Textarea } from '@/components/ui/textarea'
 import { useAuthStore } from '@/store/auth.store'
 import { refundAdminOrder, type RefundReason } from '@/lib/api/orders'
 import { ApiError } from '@/lib/api/client'
+import { captureAdminError } from '@/lib/sentry/capture-admin-error'
 
 interface RefundOrderModalProps {
   isOpen: boolean
@@ -120,7 +121,13 @@ export function RefundOrderModal({
       form.reset()
       onClose()
     },
-    onError: (error) => {
+    onError: (error, values) => {
+      captureAdminError(error, {
+        action: 'orders.refund',
+        orderId,
+        amount: values.amount ?? remainingRefundable,
+        reason: values.reason,
+      })
       const message = error instanceof ApiError ? error.message : 'Unknown error'
       toast.error(t('refundModalError', { message }))
     },

--- a/apps/web/src/app/[locale]/admin/orders/_components/admin-orders-table.tsx
+++ b/apps/web/src/app/[locale]/admin/orders/_components/admin-orders-table.tsx
@@ -42,6 +42,7 @@ import {
 } from '@/lib/api/orders'
 import { ApiError } from '@/lib/api/client'
 import type { AdminOrdersQueryParams } from '@/lib/api/orders'
+import { captureAdminError } from '@/lib/sentry/capture-admin-error'
 import { getStatusConfirmCopy, requiresStatusConfirmation } from '../_lib/status-confirm'
 
 // Mirrors the backend state machine.
@@ -121,7 +122,12 @@ export function AdminOrdersTable() {
       toast.success(t('ordersStatusUpdateSuccess', { id: updatedOrder.id.slice(-8) }))
       setPendingTransition(null)
     },
-    onError: (error) => {
+    onError: (error, variables) => {
+      captureAdminError(error, {
+        action: 'orders.updateStatus',
+        orderId: variables.orderId,
+        newStatus: variables.newStatus,
+      })
       const message = error instanceof ApiError ? error.message : t('ordersStatusUpdateError')
       toast.error(message)
     },

--- a/apps/web/src/app/[locale]/admin/products/_components/admin-products-table.tsx
+++ b/apps/web/src/app/[locale]/admin/products/_components/admin-products-table.tsx
@@ -55,6 +55,7 @@ import {
   type BulkProductAction,
 } from '@/lib/api/products'
 import { ApiError } from '@/lib/api/client'
+import { captureAdminError } from '@/lib/sentry/capture-admin-error'
 import { DeleteProductDialog } from './delete-product-dialog'
 
 const PRODUCT_STATUSES: ProductStatus[] = ['ACTIVE', 'DRAFT', 'ARCHIVED']
@@ -171,8 +172,13 @@ export function AdminProductsTable() {
     onSuccess: (updatedProduct) => {
       toast.success(t('productsStatusUpdateSuccess', { title: updatedProduct.title }))
     },
-    onError: (error, _variables, context) => {
+    onError: (error, variables, context) => {
       restoreProductsQueries(context?.previousProductsQueries)
+      captureAdminError(error, {
+        action: 'products.updateStatus',
+        productId: variables.productId,
+        newStatus: variables.newStatus,
+      })
       const message = error instanceof ApiError ? error.message : t('productsStatusUpdateError')
       toast.error(message)
     },
@@ -217,8 +223,13 @@ export function AdminProductsTable() {
       toast.success(t('productsDeleteSuccess'))
       setProductToDelete(null)
     },
-    onError: (error, _variables, context) => {
+    onError: (error, variables, context) => {
       restoreProductsQueries(context?.previousProductsQueries)
+      captureAdminError(error, {
+        action: 'products.delete',
+        productId: variables.id,
+        productSlug: variables.slug,
+      })
       const message = error instanceof ApiError ? error.message : t('productsDeleteError')
       toast.error(message)
     },
@@ -291,7 +302,12 @@ export function AdminProductsTable() {
       setPendingBulkAction(null)
       void queryClient.invalidateQueries({ queryKey: ['admin', 'products'] })
     },
-    onError: (error) => {
+    onError: (error, variables) => {
+      captureAdminError(error, {
+        action: 'products.bulk',
+        bulkAction: variables.action,
+        count: selectedIds.size,
+      })
       const message = error instanceof ApiError ? error.message : t('productsBulkActionError')
       toast.error(message)
     },

--- a/apps/web/src/lib/sentry/__tests__/capture-admin-error.test.ts
+++ b/apps/web/src/lib/sentry/__tests__/capture-admin-error.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import * as Sentry from '@sentry/nextjs'
+import {
+  suite as $allureSuite,
+  subSuite as $allureSubSuite,
+  severity as $allureSeverity,
+} from 'allure-js-commons'
+import { captureAdminError } from '../capture-admin-error'
+import { ApiError } from '@/lib/api/client'
+
+vi.mock('@sentry/nextjs', () => ({
+  captureException: vi.fn(),
+}))
+
+const mockCaptureException = vi.mocked(Sentry.captureException)
+
+beforeEach(async () => {
+  vi.clearAllMocks()
+  if (!process.env.CI) return
+  await $allureSuite('web/lib/sentry')
+  await $allureSubSuite('capture-admin-error')
+  await $allureSeverity('normal')
+})
+
+describe('captureAdminError', () => {
+  it('captures non-ApiError with adminAction tag + admin context', () => {
+    const error = new Error('Network down')
+
+    captureAdminError(error, { action: 'orders.updateStatus', orderId: 'o-1', newStatus: 'PAID' })
+
+    expect(mockCaptureException).toHaveBeenCalledWith(error, {
+      tags: { adminAction: 'orders.updateStatus' },
+      contexts: { admin: { action: 'orders.updateStatus', orderId: 'o-1', newStatus: 'PAID' } },
+    })
+  })
+
+  it('captures ApiError 5xx (upstream failure) with admin context', () => {
+    const error = new ApiError(503, 'Service unavailable')
+
+    captureAdminError(error, { action: 'products.delete', productId: 'p-1' })
+
+    expect(mockCaptureException).toHaveBeenCalledTimes(1)
+    expect(mockCaptureException).toHaveBeenCalledWith(
+      error,
+      expect.objectContaining({ tags: { adminAction: 'products.delete' } }),
+    )
+  })
+
+  it('SKIPS ApiError 4xx — user/validation errors handled by toast, not Sentry', () => {
+    const badRequest = new ApiError(400, 'Invalid slug')
+    const notFound = new ApiError(404, 'Not found')
+    const conflict = new ApiError(409, 'Conflict')
+
+    captureAdminError(badRequest, { action: 'products.create' })
+    captureAdminError(notFound, { action: 'orders.get' })
+    captureAdminError(conflict, { action: 'products.update' })
+
+    expect(mockCaptureException).not.toHaveBeenCalled()
+  })
+})

--- a/apps/web/src/lib/sentry/capture-admin-error.ts
+++ b/apps/web/src/lib/sentry/capture-admin-error.ts
@@ -1,0 +1,19 @@
+import * as Sentry from '@sentry/nextjs'
+import { ApiError } from '@/lib/api/client'
+
+interface AdminErrorContext {
+  action: string
+  [key: string]: unknown
+}
+
+// 4xx = user/validation error surfaced via toast — don't count against Sentry quota.
+// 5xx and non-ApiError (network, unexpected) always capture with admin context so
+// on-call can trace the exact orderId/productId that broke.
+export function captureAdminError(error: unknown, context: AdminErrorContext): void {
+  if (error instanceof ApiError && error.status >= 400 && error.status < 500) return
+
+  Sentry.captureException(error, {
+    tags: { adminAction: context.action },
+    contexts: { admin: context },
+  })
+}


### PR DESCRIPTION
…text) #345

## Why

<!-- What problem does this PR solve? Link to the issue. -->

Closes #

## What changed

<!-- List the key changes. Be specific. -->

-

## How to test

<!-- Steps to verify the change works correctly. -->

1.

## Checklist

- [ ] No `any` types in TypeScript
- [ ] `pnpm lint` passes
- [ ] `pnpm build` passes locally
- [ ] Self-reviewed the diff before opening PR
- [ ] QA: affected `docs/qa/**.md` test cases updated (or N/A — purely internal change)
- [ ] Admin help: if a touched admin form added/removed/renamed any field, the matching `docs/admin-help/**.md` is updated in the same PR (or N/A)
