### PR TITLE
test: E2E for wishlist + reviews eligibility flows (7 hermetic tests)…

### DIFF
--- a/apps/web/tests/e2e/reviews-wishlist.spec.ts
+++ b/apps/web/tests/e2e/reviews-wishlist.spec.ts
@@ -1,0 +1,202 @@
+import { test, expect, type Page } from '@playwright/test'
+
+test.use({ viewport: { width: 1280, height: 800 } })
+test.beforeEach(({ isMobile }) => {
+  test.skip(isMobile, 'Reviews + wishlist E2E targets desktop layout only.')
+})
+
+const FAKE_USER_JWT =
+  'eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ1c2VyLTEiLCJlbWFpbCI6InRlc3RAamV3ZWxyeS5kZXYiLCJyb2xlIjoiVVNFUiJ9.fake'
+
+const WISHLIST_PRODUCT = {
+  id: 'p1',
+  slug: 'sterling-silver-ring',
+  title: 'Sterling Silver Ring',
+  description: 'Handmade sterling silver ring',
+  price: '49.99',
+  stock: 3,
+  stockType: 'IN_STOCK' as const,
+  productionDays: 0,
+  images: ['/placeholder-product.jpg'],
+  material: 'Sterling silver',
+  avgRating: 0,
+  reviewCount: 0,
+}
+
+const REVIEWS_EMPTY = {
+  data: [],
+  meta: { totalCount: 0, avgRating: 0, page: 1, limit: 10, totalPages: 0 },
+}
+
+// Seeds Zustand persist entries before any page script runs so StoreHydration
+// sees them on its first effect tick.
+async function seedStores(
+  page: Page,
+  overrides: { auth?: string | null; wishlistIds?: string[] } = {},
+): Promise<void> {
+  const authValue = overrides.auth ?? null
+  const wishlistIds = overrides.wishlistIds ?? []
+
+  await page.addInitScript(
+    ({ auth, ids }) => {
+      if (auth) {
+        window.localStorage.setItem(
+          'auth-store',
+          JSON.stringify({ state: { accessToken: auth, refreshToken: auth }, version: 0 }),
+        )
+      }
+      window.localStorage.setItem(
+        'jewelry-wishlist',
+        JSON.stringify({ state: { productIds: ids }, version: 0 }),
+      )
+    },
+    { auth: authValue, ids: wishlistIds },
+  )
+}
+
+test.describe('Wishlist — authenticated /account/wishlist', () => {
+  test('renders products returned by GET /api/wishlist', async ({ page }) => {
+    await seedStores(page, { auth: FAKE_USER_JWT })
+    await page.route('**/api/wishlist', (route) => {
+      if (route.request().method() === 'GET') {
+        route.fulfill({ json: [WISHLIST_PRODUCT] })
+        return
+      }
+      route.fulfill({ status: 204, body: '' })
+    })
+
+    await page.goto('/en/account/wishlist')
+
+    await expect(page.getByText(WISHLIST_PRODUCT.title)).toBeVisible()
+  })
+
+  test('shows the empty state when the server returns no wishlist items', async ({ page }) => {
+    await seedStores(page, { auth: FAKE_USER_JWT })
+    await page.route('**/api/wishlist', (route) => route.fulfill({ json: [] }))
+
+    await page.goto('/en/account/wishlist')
+
+    // The empty CTA links back to the catalog — verifies the "no items" branch rendered.
+    await expect(page.getByRole('link', { name: /shop|browse|catalog/i }).first()).toBeVisible()
+  })
+
+  test('removing an item calls DELETE /api/wishlist/:productId and clears the row', async ({
+    page,
+  }) => {
+    let deleteFired = false
+    let deletedProductId: string | null = null
+
+    await seedStores(page, { auth: FAKE_USER_JWT })
+    await page.route('**/api/wishlist', (route) => route.fulfill({ json: [WISHLIST_PRODUCT] }))
+    await page.route('**/api/wishlist/*', (route) => {
+      if (route.request().method() === 'DELETE') {
+        deleteFired = true
+        deletedProductId = route.request().url().split('/').pop() ?? null
+        route.fulfill({ status: 204, body: '' })
+        return
+      }
+      route.fulfill({ status: 200, body: '' })
+    })
+
+    await page.goto('/en/account/wishlist')
+    await expect(page.getByText(WISHLIST_PRODUCT.title)).toBeVisible()
+
+    const removeButton = page.getByRole('button', { name: /remove|delete/i }).first()
+    await removeButton.click()
+
+    await expect.poll(() => deleteFired, { timeout: 5000 }).toBe(true)
+    expect(deletedProductId).toBe(WISHLIST_PRODUCT.id)
+  })
+})
+
+test.describe('Wishlist — guest persistence via localStorage', () => {
+  test('unauthenticated /account/wishlist requires login (no API call fires)', async ({ page }) => {
+    await seedStores(page)
+    let getFired = false
+    await page.route('**/api/wishlist', (route) => {
+      if (route.request().method() === 'GET') getFired = true
+      route.fulfill({ json: [] })
+    })
+
+    await page.goto('/en/account/wishlist')
+
+    // Page renders the sign-in prompt or empty catalog CTA — either is acceptable UX.
+    await page.waitForLoadState('domcontentloaded')
+    expect(getFired).toBe(false)
+  })
+})
+
+test.describe('Reviews — product page CTA per auth+eligibility', () => {
+  const PRODUCT_FIXTURE = {
+    ...WISHLIST_PRODUCT,
+    sku: null,
+    weight: null,
+    status: 'ACTIVE' as const,
+    lengthCm: null,
+    widthCm: null,
+    heightCm: null,
+    diameterCm: null,
+    weightGrams: null,
+    beadSizeMm: null,
+    categoryId: 'c1',
+    category: { name: 'Rings', slug: 'rings' },
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+  }
+
+  test('unauthenticated visitor sees the "Sign in to review" CTA', async ({ page }) => {
+    await seedStores(page)
+    await page.route(`**/api/products/${WISHLIST_PRODUCT.slug}`, (route) =>
+      route.fulfill({ json: PRODUCT_FIXTURE }),
+    )
+    await page.route('**/api/products/*/reviews**', (route) =>
+      route.fulfill({ json: REVIEWS_EMPTY }),
+    )
+
+    await page.goto(`/en/products/${WISHLIST_PRODUCT.slug}`)
+
+    await expect(page.getByRole('link', { name: /sign in to review/i })).toBeVisible()
+  })
+
+  test('authenticated + eligible customer sees the "Write review" button', async ({ page }) => {
+    await seedStores(page, { auth: FAKE_USER_JWT })
+    await page.route(`**/api/products/${WISHLIST_PRODUCT.slug}`, (route) =>
+      route.fulfill({ json: PRODUCT_FIXTURE }),
+    )
+    await page.route('**/api/products/*/reviews**', (route) =>
+      route.fulfill({ json: REVIEWS_EMPTY }),
+    )
+    await page.route('**/api/reviews/eligibility**', (route) =>
+      route.fulfill({
+        json: { hasPurchased: true, hasReviewed: false, canReview: true },
+      }),
+    )
+
+    await page.goto(`/en/products/${WISHLIST_PRODUCT.slug}`)
+
+    await expect(page.getByRole('button', { name: /write.*review/i })).toBeVisible()
+  })
+
+  test('authenticated but not-yet-purchased user sees the purchase-required message', async ({
+    page,
+  }) => {
+    await seedStores(page, { auth: FAKE_USER_JWT })
+    await page.route(`**/api/products/${WISHLIST_PRODUCT.slug}`, (route) =>
+      route.fulfill({ json: PRODUCT_FIXTURE }),
+    )
+    await page.route('**/api/products/*/reviews**', (route) =>
+      route.fulfill({ json: REVIEWS_EMPTY }),
+    )
+    await page.route('**/api/reviews/eligibility**', (route) =>
+      route.fulfill({
+        json: { hasPurchased: false, hasReviewed: false, canReview: false },
+      }),
+    )
+
+    await page.goto(`/en/products/${WISHLIST_PRODUCT.slug}`)
+
+    // The gate copy is any of "purchase required" / "you must have purchased" — case-insensitive to survive i18n key edits.
+    await expect(page.getByText(/purchase/i).first()).toBeVisible()
+    await expect(page.getByRole('button', { name: /write.*review/i })).not.toBeVisible()
+  })
+})


### PR DESCRIPTION
… #344

## Why

<!-- What problem does this PR solve? Link to the issue. -->

Closes #

## What changed

<!-- List the key changes. Be specific. -->

-

## How to test

<!-- Steps to verify the change works correctly. -->

1.

## Checklist

- [ ] No `any` types in TypeScript
- [ ] `pnpm lint` passes
- [ ] `pnpm build` passes locally
- [ ] Self-reviewed the diff before opening PR
- [ ] QA: affected `docs/qa/**.md` test cases updated (or N/A — purely internal change)
- [ ] Admin help: if a touched admin form added/removed/renamed any field, the matching `docs/admin-help/**.md` is updated in the same PR (or N/A)
