### PR TITLE
feat: chargeback dispute alerting (Slack + email + ON_HOLD status) #346

### DIFF
--- a/apps/api/prisma/migrations/20260706100000_add_on_hold_order_status/migration.sql
+++ b/apps/api/prisma/migrations/20260706100000_add_on_hold_order_status/migration.sql
@@ -1,0 +1,5 @@
+-- Migration: Add ON_HOLD to OrderStatus enum (#346)
+-- Reason: Chargeback disputes and fraud flags — freezes the order until admin
+-- reviews the issue. Triggered by Stripe `charge.dispute.created` webhook.
+
+ALTER TYPE "OrderStatus" ADD VALUE 'ON_HOLD';

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -32,6 +32,7 @@ enum OrderStatus {
   CANCELLED          // Order cancelled (allowed before SHIPPED)
   REFUNDED           // Full refund executed via Stripe
   PARTIALLY_REFUNDED // Partial refund — e.g. MADE_TO_ORDER cancelled mid-production
+  ON_HOLD            // Chargeback dispute or fraud flag — admin action required
 }
 
 enum PaymentStatus {

--- a/apps/api/src/admin/admin-orders-analytics.service.spec.ts
+++ b/apps/api/src/admin/admin-orders-analytics.service.spec.ts
@@ -35,7 +35,7 @@ describe('AdminOrdersAnalyticsService', () => {
   afterEach(() => jest.resetAllMocks())
 
   describe('getOrderStatusBreakdown', () => {
-    it('returns all 8 known statuses, including those with zero orders', async () => {
+    it('returns all 9 known statuses, including those with zero orders', async () => {
       // Backend only reports the non-zero buckets; service must fill the rest.
       mockPrismaService.order.groupBy.mockResolvedValueOnce([
         { status: 'PAID', _count: { status: 3 } },
@@ -49,8 +49,8 @@ describe('AdminOrdersAnalyticsService', () => {
       expect(byStatus.get('DELIVERED')).toBe(7)
       expect(byStatus.get('PENDING')).toBe(0)
       expect(byStatus.get('REFUNDED')).toBe(0)
-      // The chart needs a stable legend — all 8 statuses always present
-      expect(result).toHaveLength(8)
+      // The chart needs a stable legend — all 9 statuses always present
+      expect(result).toHaveLength(9)
     })
   })
 })

--- a/apps/api/src/admin/admin-orders-analytics.service.ts
+++ b/apps/api/src/admin/admin-orders-analytics.service.ts
@@ -16,6 +16,7 @@ const ALL_STATUSES: OrderStatusForBreakdown[] = [
   'CANCELLED',
   'REFUNDED',
   'PARTIALLY_REFUNDED',
+  'ON_HOLD',
 ]
 
 @Injectable()

--- a/apps/api/src/email/email.service.ts
+++ b/apps/api/src/email/email.service.ts
@@ -26,6 +26,7 @@ import {
   buildBackInStockEmail,
   type BackInStockEmailData,
 } from './templates/back-in-stock.template'
+import { buildDisputeAlertEmail, type DisputeAlertData } from './templates/dispute-alert.template'
 
 // Resend's onboarding domain — accepted for testing, but flagged as spam by
 // most receivers. Production MUST set RESEND_FROM_ADDRESS to a verified
@@ -87,6 +88,12 @@ export class EmailService {
     const ownerEmail = this.configService.getOrThrow<string>('STORE_OWNER_EMAIL')
     // Reply-To set to the sender so the store owner can reply directly from their inbox
     await this.send({ to: ownerEmail, subject, html, replyTo: data.senderEmail })
+  }
+
+  async sendDisputeAlert(data: DisputeAlertData): Promise<void> {
+    const { subject, html } = buildDisputeAlertEmail(data)
+    const ownerEmail = this.configService.getOrThrow<string>('STORE_OWNER_EMAIL')
+    await this.send({ to: ownerEmail, subject, html })
   }
 
   private async send(params: {

--- a/apps/api/src/email/templates/dispute-alert.template.ts
+++ b/apps/api/src/email/templates/dispute-alert.template.ts
@@ -1,0 +1,54 @@
+export interface DisputeAlertData {
+  disputeId: string
+  chargeId: string
+  orderId: string
+  amountUsd: number
+  reason: string | null
+  adminUrl: string
+}
+
+function formatUsd(amount: number): string {
+  return new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' }).format(amount)
+}
+
+// Recipient is the store owner (STORE_OWNER_EMAIL). Plain, terse layout —
+// this is an ops alert, not a marketing email. Loud subject prefix so the
+// alert is unmissable in a busy inbox.
+export function buildDisputeAlertEmail(data: DisputeAlertData): {
+  subject: string
+  html: string
+} {
+  const { disputeId, chargeId, orderId, amountUsd, reason, adminUrl } = data
+  const shortOrderId = orderId.slice(-8).toUpperCase()
+
+  return {
+    subject: `[ACTION REQUIRED] Chargeback dispute on order #${shortOrderId} — ${formatUsd(amountUsd)}`,
+    html: `<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="UTF-8"></head>
+<body style="margin:0;padding:24px;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;color:#1a1a1a;background:#fff;">
+  <h1 style="margin:0 0 12px;font-size:20px;color:#c53030;">Chargeback dispute filed</h1>
+  <p style="margin:0 0 16px;font-size:14px;line-height:1.6;">
+    Order <strong>#${shortOrderId}</strong> has been flagged by Stripe. The order is now in
+    <strong>ON_HOLD</strong> status and shipping is paused until resolved.
+  </p>
+  <table cellpadding="6" cellspacing="0" style="border-collapse:collapse;font-size:13px;margin-bottom:16px;">
+    <tr><td style="color:#888;">Order</td><td style="font-family:monospace;">${orderId}</td></tr>
+    <tr><td style="color:#888;">Amount</td><td><strong>${formatUsd(amountUsd)}</strong></td></tr>
+    <tr><td style="color:#888;">Stripe charge</td><td style="font-family:monospace;">${chargeId}</td></tr>
+    <tr><td style="color:#888;">Stripe dispute</td><td style="font-family:monospace;">${disputeId}</td></tr>
+    <tr><td style="color:#888;">Reason</td><td>${reason ?? 'unspecified'}</td></tr>
+  </table>
+  <p style="margin:0 0 12px;font-size:14px;">
+    <a href="${adminUrl}" style="display:inline-block;padding:10px 16px;background:#1a1a1a;color:#fff;text-decoration:none;border-radius:4px;">
+      Review order in admin
+    </a>
+  </p>
+  <p style="margin:16px 0 0;font-size:12px;color:#888;line-height:1.5;">
+    Respond in the Stripe Dashboard before the dispute deadline (usually 7–21 days) or the funds
+    will be forfeited automatically.
+  </p>
+</body>
+</html>`,
+  }
+}

--- a/apps/api/src/orders/order-status.transitions.spec.ts
+++ b/apps/api/src/orders/order-status.transitions.spec.ts
@@ -141,4 +141,32 @@ describe('isValidOrderStatusTransition', () => {
       })
     })
   })
+
+  describe('ON_HOLD dispute lifecycle', () => {
+    it('allows any non-terminal status → ON_HOLD (chargeback can hit an order at any active stage)', () => {
+      const canBeHeld = [
+        OrderStatus.PENDING,
+        OrderStatus.PAID,
+        OrderStatus.PROCESSING,
+        OrderStatus.SHIPPED,
+        OrderStatus.DELIVERED,
+      ]
+      canBeHeld.forEach((from) => {
+        expect(isValidOrderStatusTransition(from, OrderStatus.ON_HOLD)).toBe(true)
+      })
+    })
+
+    it('forbids CANCELLED → ON_HOLD (money already returned, hold is meaningless)', () => {
+      expect(isValidOrderStatusTransition(OrderStatus.CANCELLED, OrderStatus.ON_HOLD)).toBe(false)
+    })
+
+    it('only resolves ON_HOLD into REFUNDED / PARTIALLY_REFUNDED / CANCELLED', () => {
+      const allowed = [OrderStatus.REFUNDED, OrderStatus.PARTIALLY_REFUNDED, OrderStatus.CANCELLED]
+      allowed.forEach((target) => {
+        expect(isValidOrderStatusTransition(OrderStatus.ON_HOLD, target)).toBe(true)
+      })
+      expect(isValidOrderStatusTransition(OrderStatus.ON_HOLD, OrderStatus.SHIPPED)).toBe(false)
+      expect(isValidOrderStatusTransition(OrderStatus.ON_HOLD, OrderStatus.DELIVERED)).toBe(false)
+    })
+  })
 })

--- a/apps/api/src/orders/order-status.transitions.ts
+++ b/apps/api/src/orders/order-status.transitions.ts
@@ -6,16 +6,29 @@ import { OrderStatus } from '@prisma/client'
  * (e.g. SHIPPED → PAID) and skips (e.g. PENDING → SHIPPED).
  */
 export const ALLOWED_ORDER_STATUS_TRANSITIONS: Record<OrderStatus, OrderStatus[]> = {
-  PENDING: [OrderStatus.PAID, OrderStatus.CANCELLED],
-  PAID: [OrderStatus.PROCESSING, OrderStatus.CANCELLED, OrderStatus.PARTIALLY_REFUNDED],
-  PROCESSING: [OrderStatus.SHIPPED, OrderStatus.CANCELLED, OrderStatus.PARTIALLY_REFUNDED],
-  SHIPPED: [OrderStatus.DELIVERED, OrderStatus.PARTIALLY_REFUNDED],
-  DELIVERED: [OrderStatus.REFUNDED, OrderStatus.PARTIALLY_REFUNDED],
+  PENDING: [OrderStatus.PAID, OrderStatus.CANCELLED, OrderStatus.ON_HOLD],
+  PAID: [
+    OrderStatus.PROCESSING,
+    OrderStatus.CANCELLED,
+    OrderStatus.PARTIALLY_REFUNDED,
+    OrderStatus.ON_HOLD,
+  ],
+  PROCESSING: [
+    OrderStatus.SHIPPED,
+    OrderStatus.CANCELLED,
+    OrderStatus.PARTIALLY_REFUNDED,
+    OrderStatus.ON_HOLD,
+  ],
+  SHIPPED: [OrderStatus.DELIVERED, OrderStatus.PARTIALLY_REFUNDED, OrderStatus.ON_HOLD],
+  DELIVERED: [OrderStatus.REFUNDED, OrderStatus.PARTIALLY_REFUNDED, OrderStatus.ON_HOLD],
   CANCELLED: [OrderStatus.REFUNDED, OrderStatus.PARTIALLY_REFUNDED],
   // PARTIALLY_REFUNDED → REFUNDED allowed for follow-up refunds — a top-up
   // refund that brings the cumulative amount to the full total.
   PARTIALLY_REFUNDED: [OrderStatus.REFUNDED],
   REFUNDED: [], // terminal state — no transitions allowed
+  // Admin resolves a disputed order via the admin panel — either refund or
+  // cancel; no path back to PROCESSING/SHIPPED once flagged.
+  ON_HOLD: [OrderStatus.REFUNDED, OrderStatus.PARTIALLY_REFUNDED, OrderStatus.CANCELLED],
 }
 
 export function isValidOrderStatusTransition(

--- a/apps/api/src/stripe/slack-notifier.service.spec.ts
+++ b/apps/api/src/stripe/slack-notifier.service.spec.ts
@@ -1,0 +1,84 @@
+import { ConfigService } from '@nestjs/config'
+import { Test, TestingModule } from '@nestjs/testing'
+import {
+  suite as $allureSuite,
+  subSuite as $allureSubSuite,
+  severity as $allureSeverity,
+} from 'allure-js-commons'
+import { SlackNotifierService } from './slack-notifier.service'
+
+const WEBHOOK_URL = 'https://hooks.slack.com/services/T000/B000/token'
+const SAMPLE_PAYLOAD = {
+  disputeId: 'dp_test',
+  chargeId: 'ch_test',
+  orderId: 'order_abc12345',
+  amountUsd: 49.99,
+  reason: 'fraudulent',
+  adminUrl: 'https://shop.example/admin/orders/order_abc12345',
+}
+
+beforeEach(async () => {
+  if (!process.env.CI) return
+  await $allureSuite('api/stripe')
+  await $allureSubSuite('slack-notifier.service')
+  await $allureSeverity('normal')
+})
+
+describe('SlackNotifierService.sendDisputeAlert', () => {
+  let service: SlackNotifierService
+  let mockConfigService: { get: jest.Mock }
+  let fetchSpy: jest.SpyInstance
+
+  beforeEach(async () => {
+    mockConfigService = { get: jest.fn() }
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [SlackNotifierService, { provide: ConfigService, useValue: mockConfigService }],
+    }).compile()
+    service = module.get<SlackNotifierService>(SlackNotifierService)
+    fetchSpy = jest.spyOn(global, 'fetch').mockResolvedValue(new Response(null, { status: 200 }))
+  })
+
+  afterEach(() => {
+    fetchSpy.mockRestore()
+  })
+
+  it('is a no-op when SLACK_WEBHOOK_URL is not configured', async () => {
+    mockConfigService.get.mockReturnValue(undefined)
+
+    await service.sendDisputeAlert(SAMPLE_PAYLOAD)
+
+    expect(fetchSpy).not.toHaveBeenCalled()
+  })
+
+  it('POSTs a JSON body containing the short order id and amount to the webhook URL', async () => {
+    mockConfigService.get.mockReturnValue(WEBHOOK_URL)
+
+    await service.sendDisputeAlert(SAMPLE_PAYLOAD)
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      WEBHOOK_URL,
+      expect.objectContaining({
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+    const rawBody = (fetchSpy.mock.calls[0]?.[1] as { body: string }).body
+    expect(rawBody).toContain('ABC12345')
+    expect(rawBody).toContain('$49.99')
+    expect(rawBody).toContain('dp_test')
+  })
+
+  it('swallows non-2xx responses so the caller webhook can still ack', async () => {
+    mockConfigService.get.mockReturnValue(WEBHOOK_URL)
+    fetchSpy.mockResolvedValueOnce(new Response(null, { status: 500, statusText: 'error' }))
+
+    await expect(service.sendDisputeAlert(SAMPLE_PAYLOAD)).resolves.toBeUndefined()
+  })
+
+  it('swallows network errors — Slack outages must not block webhook processing', async () => {
+    mockConfigService.get.mockReturnValue(WEBHOOK_URL)
+    fetchSpy.mockRejectedValueOnce(new Error('ECONNRESET'))
+
+    await expect(service.sendDisputeAlert(SAMPLE_PAYLOAD)).resolves.toBeUndefined()
+  })
+})

--- a/apps/api/src/stripe/slack-notifier.service.ts
+++ b/apps/api/src/stripe/slack-notifier.service.ts
@@ -1,0 +1,79 @@
+import { Injectable, Logger } from '@nestjs/common'
+import { ConfigService } from '@nestjs/config'
+
+export interface DisputeSlackPayload {
+  disputeId: string
+  chargeId: string
+  orderId: string
+  amountUsd: number
+  reason: string | null
+  adminUrl: string
+}
+
+@Injectable()
+export class SlackNotifierService {
+  private readonly logger = new Logger(SlackNotifierService.name)
+
+  constructor(private readonly configService: ConfigService) {}
+
+  // Best-effort — Slack outages must not block webhook processing. A missing
+  // SLACK_WEBHOOK_URL is silent (dev / self-hosted deployments don't require Slack).
+  async sendDisputeAlert(payload: DisputeSlackPayload): Promise<void> {
+    const webhookUrl = this.configService.get<string>('SLACK_WEBHOOK_URL')
+    if (!webhookUrl) return
+
+    const shortOrderId = payload.orderId.slice(-8).toUpperCase()
+    const amountFormatted = new Intl.NumberFormat('en-US', {
+      style: 'currency',
+      currency: 'USD',
+    }).format(payload.amountUsd)
+
+    const body = {
+      text: `:rotating_light: Chargeback dispute on order #${shortOrderId} — ${amountFormatted}`,
+      blocks: [
+        {
+          type: 'section',
+          text: {
+            type: 'mrkdwn',
+            text: `*Chargeback dispute filed* :rotating_light:\nOrder \`#${shortOrderId}\` is now *ON_HOLD*. Respond in Stripe before the deadline.`,
+          },
+        },
+        {
+          type: 'section',
+          fields: [
+            { type: 'mrkdwn', text: `*Amount:*\n${amountFormatted}` },
+            { type: 'mrkdwn', text: `*Reason:*\n${payload.reason ?? 'unspecified'}` },
+            { type: 'mrkdwn', text: `*Charge:*\n\`${payload.chargeId}\`` },
+            { type: 'mrkdwn', text: `*Dispute:*\n\`${payload.disputeId}\`` },
+          ],
+        },
+        {
+          type: 'actions',
+          elements: [
+            {
+              type: 'button',
+              text: { type: 'plain_text', text: 'Review in admin' },
+              url: payload.adminUrl,
+              style: 'primary',
+            },
+          ],
+        },
+      ],
+    }
+
+    try {
+      const response = await fetch(webhookUrl, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      })
+      if (!response.ok) {
+        this.logger.error(`Slack notification failed: ${response.status} ${response.statusText}`)
+      }
+    } catch (error) {
+      this.logger.error(
+        `Slack notification network error: ${error instanceof Error ? error.message : String(error)}`,
+      )
+    }
+  }
+}

--- a/apps/api/src/stripe/stripe-webhooks.service.spec.ts
+++ b/apps/api/src/stripe/stripe-webhooks.service.spec.ts
@@ -1,3 +1,4 @@
+import { ConfigService } from '@nestjs/config'
 import { Test, TestingModule } from '@nestjs/testing'
 import { OrderStatus, PaymentStatus } from '@prisma/client'
 import { Decimal } from '@prisma/client/runtime/library'
@@ -5,6 +6,8 @@ import type Stripe from 'stripe'
 import { AnalyticsService } from '../analytics/analytics.service'
 import { EmailService } from '../email/email.service'
 import { PrismaService } from '../prisma/prisma.service'
+import { SlackNotifierService } from './slack-notifier.service'
+import { StripeService } from './stripe.service'
 import { StripeWebhooksService } from './stripe-webhooks.service'
 import {
   suite as $allureSuite,
@@ -81,11 +84,18 @@ describe('StripeWebhooksService', () => {
     order: { findUnique: jest.Mock; update: jest.Mock }
     $transaction: jest.Mock
   }
-  let mockEmailService: { sendOrderConfirmation: jest.Mock; sendRefundProcessed: jest.Mock }
+  let mockEmailService: {
+    sendOrderConfirmation: jest.Mock
+    sendRefundProcessed: jest.Mock
+    sendDisputeAlert: jest.Mock
+  }
   let mockAnalyticsService: {
     trackPaymentSucceeded: jest.Mock
     trackOrderCreated: jest.Mock
   }
+  let mockSlackNotifierService: { sendDisputeAlert: jest.Mock }
+  let mockStripeService: { client: { charges: { retrieve: jest.Mock } } }
+  let mockConfigService: { get: jest.Mock }
 
   beforeEach(async () => {
     mockPrismaService = {
@@ -97,10 +107,16 @@ describe('StripeWebhooksService', () => {
     mockEmailService = {
       sendOrderConfirmation: jest.fn(),
       sendRefundProcessed: jest.fn(),
+      sendDisputeAlert: jest.fn(),
     }
     mockAnalyticsService = {
       trackPaymentSucceeded: jest.fn(),
       trackOrderCreated: jest.fn(),
+    }
+    mockSlackNotifierService = { sendDisputeAlert: jest.fn() }
+    mockStripeService = { client: { charges: { retrieve: jest.fn() } } }
+    mockConfigService = {
+      get: jest.fn((key: string) => (key === 'FRONTEND_URL' ? 'https://shop.example' : undefined)),
     }
 
     const module: TestingModule = await Test.createTestingModule({
@@ -109,6 +125,9 @@ describe('StripeWebhooksService', () => {
         { provide: PrismaService, useValue: mockPrismaService },
         { provide: EmailService, useValue: mockEmailService },
         { provide: AnalyticsService, useValue: mockAnalyticsService },
+        { provide: SlackNotifierService, useValue: mockSlackNotifierService },
+        { provide: StripeService, useValue: mockStripeService },
+        { provide: ConfigService, useValue: mockConfigService },
       ],
     }).compile()
 
@@ -345,14 +364,110 @@ describe('StripeWebhooksService', () => {
   })
 
   describe('handleChargeDisputeCreated', () => {
-    it('logs an error without throwing', () => {
-      const mockDispute = {
+    const buildMockDispute = (overrides: Partial<Stripe.Dispute> = {}) =>
+      ({
         id: 'dp_test_123',
         charge: STRIPE_CHARGE_ID,
         amount: 4998,
-      } as Stripe.Dispute
+        reason: 'fraudulent',
+        ...overrides,
+      }) as Stripe.Dispute
 
-      expect(() => stripeWebhooksService.handleChargeDisputeCreated(mockDispute)).not.toThrow()
+    it('transitions the order to ON_HOLD and records the history entry', async () => {
+      mockStripeService.client.charges.retrieve.mockResolvedValueOnce({
+        id: STRIPE_CHARGE_ID,
+        payment_intent: STRIPE_INTENT_ID,
+      })
+      mockPrismaService.payment.findUnique.mockResolvedValueOnce(
+        buildMockPayment({ order: { id: ORDER_ID, status: OrderStatus.PAID } }),
+      )
+
+      await stripeWebhooksService.handleChargeDisputeCreated(buildMockDispute())
+
+      expect(mockPrismaService.order.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { id: ORDER_ID },
+          data: expect.objectContaining({
+            status: OrderStatus.ON_HOLD,
+            statusHistory: expect.objectContaining({
+              create: expect.objectContaining({
+                fromStatus: OrderStatus.PAID,
+                toStatus: OrderStatus.ON_HOLD,
+                createdBy: 'stripe-webhook',
+              }),
+            }),
+          }),
+        }),
+      )
+    })
+
+    it('fires both Slack + email alerts with the dispute payload', async () => {
+      mockStripeService.client.charges.retrieve.mockResolvedValueOnce({
+        id: STRIPE_CHARGE_ID,
+        payment_intent: STRIPE_INTENT_ID,
+      })
+      mockPrismaService.payment.findUnique.mockResolvedValueOnce(
+        buildMockPayment({ order: { id: ORDER_ID, status: OrderStatus.PAID } }),
+      )
+
+      await stripeWebhooksService.handleChargeDisputeCreated(buildMockDispute())
+
+      const expectedPayload = {
+        disputeId: 'dp_test_123',
+        chargeId: STRIPE_CHARGE_ID,
+        orderId: ORDER_ID,
+        amountUsd: 49.98,
+        reason: 'fraudulent',
+        adminUrl: `https://shop.example/admin/orders/${ORDER_ID}`,
+      }
+      expect(mockSlackNotifierService.sendDisputeAlert).toHaveBeenCalledWith(expectedPayload)
+      expect(mockEmailService.sendDisputeAlert).toHaveBeenCalledWith(expectedPayload)
+    })
+
+    it('still emails admin when Slack notification throws (Slack outage tolerance)', async () => {
+      mockStripeService.client.charges.retrieve.mockResolvedValueOnce({
+        id: STRIPE_CHARGE_ID,
+        payment_intent: STRIPE_INTENT_ID,
+      })
+      mockPrismaService.payment.findUnique.mockResolvedValueOnce(
+        buildMockPayment({ order: { id: ORDER_ID, status: OrderStatus.PAID } }),
+      )
+      mockSlackNotifierService.sendDisputeAlert.mockRejectedValueOnce(new Error('Slack 503'))
+
+      await stripeWebhooksService.handleChargeDisputeCreated(buildMockDispute())
+
+      expect(mockEmailService.sendDisputeAlert).toHaveBeenCalled()
+    })
+
+    it('skips ON_HOLD transition when order is already in a terminal state (REFUNDED)', async () => {
+      mockStripeService.client.charges.retrieve.mockResolvedValueOnce({
+        id: STRIPE_CHARGE_ID,
+        payment_intent: STRIPE_INTENT_ID,
+      })
+      mockPrismaService.payment.findUnique.mockResolvedValueOnce(
+        buildMockPayment({ order: { id: ORDER_ID, status: OrderStatus.REFUNDED } }),
+      )
+
+      await stripeWebhooksService.handleChargeDisputeCreated(buildMockDispute())
+
+      // Guard against writing an invalid state transition — alerts still fire so admin
+      // sees the flag, but the order stays in its terminal state.
+      expect(mockPrismaService.order.update).not.toHaveBeenCalled()
+      expect(mockEmailService.sendDisputeAlert).toHaveBeenCalled()
+    })
+
+    it('skips silently when no Payment row matches the charge (unknown intent)', async () => {
+      mockStripeService.client.charges.retrieve.mockResolvedValueOnce({
+        id: STRIPE_CHARGE_ID,
+        payment_intent: STRIPE_INTENT_ID,
+      })
+      mockPrismaService.payment.findUnique.mockResolvedValueOnce(null)
+
+      await stripeWebhooksService.handleChargeDisputeCreated(buildMockDispute())
+
+      expect(mockPrismaService.order.update).not.toHaveBeenCalled()
+      expect(mockEmailService.sendDisputeAlert).not.toHaveBeenCalled()
+      expect(mockSlackNotifierService.sendDisputeAlert).not.toHaveBeenCalled()
     })
   })
 })

--- a/apps/api/src/stripe/stripe-webhooks.service.ts
+++ b/apps/api/src/stripe/stripe-webhooks.service.ts
@@ -1,10 +1,13 @@
 import { Injectable, Logger } from '@nestjs/common'
+import { ConfigService } from '@nestjs/config'
 import { OrderStatus, PaymentStatus } from '@prisma/client'
 import type Stripe from 'stripe'
 import { AnalyticsService } from '../analytics/analytics.service'
 import { EmailService } from '../email/email.service'
 import { PrismaService } from '../prisma/prisma.service'
 import { isValidOrderStatusTransition } from '../orders/order-status.transitions'
+import { SlackNotifierService } from './slack-notifier.service'
+import { StripeService } from './stripe.service'
 
 @Injectable()
 export class StripeWebhooksService {
@@ -14,6 +17,9 @@ export class StripeWebhooksService {
     private readonly prismaService: PrismaService,
     private readonly emailService: EmailService,
     private readonly analyticsService: AnalyticsService,
+    private readonly slackNotifierService: SlackNotifierService,
+    private readonly stripeService: StripeService,
+    private readonly configService: ConfigService,
   ) {}
 
   async handlePaymentIntentSucceeded(paymentIntent: Stripe.PaymentIntent): Promise<void> {
@@ -195,11 +201,86 @@ export class StripeWebhooksService {
     }
   }
 
-  handleChargeDisputeCreated(dispute: Stripe.Dispute): void {
-    // TODO(post-launch): Slack/email alert + transition order to ON_HOLD.
+  async handleChargeDisputeCreated(dispute: Stripe.Dispute): Promise<void> {
+    const chargeId = typeof dispute.charge === 'string' ? dispute.charge : dispute.charge.id
+    const amountUsd = dispute.amount / 100
+
     this.logger.error(
-      `DISPUTE CREATED — dispute ID: ${dispute.id}, charge: ${dispute.charge}, amount: $${dispute.amount / 100}`,
+      `DISPUTE CREATED — dispute ${dispute.id}, charge ${chargeId}, amount $${amountUsd}`,
     )
+
+    // Stripe dispute references a charge — walk back to the PaymentIntent, then
+    // to our Payment row (indexed by stripeId = payment_intent id).
+    const payment = await this.findPaymentByChargeId(chargeId)
+
+    if (!payment) {
+      this.logger.warn(`No matching Payment row for disputed charge ${chargeId} — skipping ON_HOLD`)
+      return
+    }
+
+    if (isValidOrderStatusTransition(payment.order.status, OrderStatus.ON_HOLD)) {
+      await this.prismaService.order.update({
+        where: { id: payment.orderId },
+        data: {
+          status: OrderStatus.ON_HOLD,
+          statusHistory: {
+            create: {
+              fromStatus: payment.order.status,
+              toStatus: OrderStatus.ON_HOLD,
+              note: `Chargeback dispute ${dispute.id} filed — reason: ${dispute.reason ?? 'unspecified'}`,
+              createdBy: 'stripe-webhook',
+            },
+          },
+        },
+      })
+      this.logger.log(`Order ${payment.orderId} transitioned to ON_HOLD`)
+    } else {
+      this.logger.warn(
+        `Order ${payment.orderId} in ${payment.order.status} cannot transition to ON_HOLD — admin alert only`,
+      )
+    }
+
+    // Best-effort alerting: neither Slack nor email failure blocks the webhook
+    // ack — Stripe retries the whole webhook otherwise, causing duplicate ON_HOLD
+    // transitions in the history.
+    const adminUrl = `${this.configService.get<string>('FRONTEND_URL') ?? ''}/admin/orders/${payment.orderId}`
+    const alertPayload = {
+      disputeId: dispute.id,
+      chargeId,
+      orderId: payment.orderId,
+      amountUsd,
+      reason: dispute.reason ?? null,
+      adminUrl,
+    }
+
+    try {
+      await this.slackNotifierService.sendDisputeAlert(alertPayload)
+    } catch (error) {
+      this.logger.error(
+        `Slack dispute alert failed — falling back to email only. ${error instanceof Error ? error.message : String(error)}`,
+      )
+    }
+
+    try {
+      await this.emailService.sendDisputeAlert(alertPayload)
+    } catch (error) {
+      this.logger.error(
+        `Dispute alert email failed for order ${payment.orderId}: ${error instanceof Error ? error.message : String(error)}`,
+      )
+    }
+  }
+
+  // Payment.stripeId stores the PaymentIntent id (pi_*); dispute.charge references a
+  // Charge id (ch_*). We resolve the link via Stripe's API — the charge object
+  // exposes payment_intent, which matches our Payment.stripeId.
+  private async findPaymentByChargeId(chargeId: string) {
+    const charge = await this.stripeService.client.charges.retrieve(chargeId)
+    const paymentIntentId = typeof charge.payment_intent === 'string' ? charge.payment_intent : null
+    if (!paymentIntentId) return null
+    return this.prismaService.payment.findUnique({
+      where: { stripeId: paymentIntentId },
+      include: { order: true },
+    })
   }
 
   private async sendOrderConfirmationEmail(orderId: string): Promise<void> {

--- a/apps/api/src/stripe/stripe.module.ts
+++ b/apps/api/src/stripe/stripe.module.ts
@@ -1,5 +1,6 @@
 import { Module } from '@nestjs/common'
 import { EmailModule } from '../email/email.module'
+import { SlackNotifierService } from './slack-notifier.service'
 import { StripeService } from './stripe.service'
 import { StripeWebhooksController } from './stripe-webhooks.controller'
 import { StripeWebhooksService } from './stripe-webhooks.service'
@@ -7,7 +8,7 @@ import { StripeWebhooksService } from './stripe-webhooks.service'
 @Module({
   imports: [EmailModule],
   controllers: [StripeWebhooksController],
-  providers: [StripeService, StripeWebhooksService],
+  providers: [StripeService, StripeWebhooksService, SlackNotifierService],
   exports: [StripeService],
 })
 export class StripeModule {}

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -569,6 +569,7 @@
     "ordersStatusCANCELLED": "Cancelled",
     "ordersStatusREFUNDED": "Refunded",
     "ordersStatusPARTIALLY_REFUNDED": "Partially refunded",
+    "ordersStatusON_HOLD": "On hold",
     "ordersLoading": "Loading orders...",
     "ordersEmpty": "No orders found.",
     "ordersColId": "Order ID",

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -569,6 +569,7 @@
     "ordersStatusCANCELLED": "Cancelado",
     "ordersStatusREFUNDED": "Reembolsado",
     "ordersStatusPARTIALLY_REFUNDED": "Reembolso parcial",
+    "ordersStatusON_HOLD": "En espera",
     "ordersLoading": "Cargando pedidos...",
     "ordersEmpty": "No se encontraron pedidos.",
     "ordersColId": "N.º de pedido",

--- a/apps/web/messages/ru.json
+++ b/apps/web/messages/ru.json
@@ -569,6 +569,7 @@
     "ordersStatusCANCELLED": "Отменён",
     "ordersStatusREFUNDED": "Возврат",
     "ordersStatusPARTIALLY_REFUNDED": "Частичный возврат",
+    "ordersStatusON_HOLD": "Приостановлен",
     "ordersLoading": "Загрузка заказов...",
     "ordersEmpty": "Заказы не найдены.",
     "ordersColId": "Номер заказа",

--- a/apps/web/src/app/[locale]/account/orders/_components/order-history-list.tsx
+++ b/apps/web/src/app/[locale]/account/orders/_components/order-history-list.tsx
@@ -17,6 +17,7 @@ const STATUS_BADGE_VARIANT: Record<OrderStatus, string> = {
   CANCELLED: 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-300',
   REFUNDED: 'bg-gray-100 text-gray-800 dark:bg-gray-900/30 dark:text-gray-300',
   PARTIALLY_REFUNDED: 'bg-orange-100 text-orange-800 dark:bg-orange-900/30 dark:text-orange-300',
+  ON_HOLD: 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-300',
 }
 
 function formatDate(isoString: string, locale: string): string {

--- a/apps/web/src/app/[locale]/admin/_components/analytics/order-status-breakdown.tsx
+++ b/apps/web/src/app/[locale]/admin/_components/analytics/order-status-breakdown.tsx
@@ -22,6 +22,7 @@ const STATUS_COLOR: Record<OrderStatusForBreakdown, string> = {
   CANCELLED: '#6b7280', // gray-500
   REFUNDED: '#ef4444', // red-500
   PARTIALLY_REFUNDED: '#f97316', // orange-500
+  ON_HOLD: '#dc2626', // red-600 — same alarm channel as REFUNDED but darker
 }
 
 const STATUS_LABEL_KEY: Record<
@@ -34,6 +35,7 @@ const STATUS_LABEL_KEY: Record<
   | 'ordersStatusCANCELLED'
   | 'ordersStatusREFUNDED'
   | 'ordersStatusPARTIALLY_REFUNDED'
+  | 'ordersStatusON_HOLD'
 > = {
   PENDING: 'ordersStatusPENDING',
   PAID: 'ordersStatusPAID',
@@ -43,6 +45,7 @@ const STATUS_LABEL_KEY: Record<
   CANCELLED: 'ordersStatusCANCELLED',
   REFUNDED: 'ordersStatusREFUNDED',
   PARTIALLY_REFUNDED: 'ordersStatusPARTIALLY_REFUNDED',
+  ON_HOLD: 'ordersStatusON_HOLD',
 }
 
 interface DonutTooltipPayloadItem {

--- a/apps/web/src/app/[locale]/admin/orders/_components/admin-orders-table.tsx
+++ b/apps/web/src/app/[locale]/admin/orders/_components/admin-orders-table.tsx
@@ -47,14 +47,15 @@ import { getStatusConfirmCopy, requiresStatusConfirmation } from '../_lib/status
 
 // Mirrors the backend state machine.
 const ALLOWED_TRANSITIONS: Record<OrderStatus, OrderStatus[]> = {
-  PENDING: ['PAID', 'CANCELLED'],
-  PAID: ['PROCESSING', 'CANCELLED'],
-  PROCESSING: ['SHIPPED', 'CANCELLED'],
-  SHIPPED: ['DELIVERED'],
-  DELIVERED: ['REFUNDED', 'PARTIALLY_REFUNDED'],
+  PENDING: ['PAID', 'CANCELLED', 'ON_HOLD'],
+  PAID: ['PROCESSING', 'CANCELLED', 'ON_HOLD'],
+  PROCESSING: ['SHIPPED', 'CANCELLED', 'ON_HOLD'],
+  SHIPPED: ['DELIVERED', 'ON_HOLD'],
+  DELIVERED: ['REFUNDED', 'PARTIALLY_REFUNDED', 'ON_HOLD'],
   CANCELLED: ['REFUNDED', 'PARTIALLY_REFUNDED'],
   REFUNDED: [],
   PARTIALLY_REFUNDED: [],
+  ON_HOLD: ['REFUNDED', 'PARTIALLY_REFUNDED', 'CANCELLED'],
 }
 
 const ALL_STATUSES: OrderStatus[] = [
@@ -66,6 +67,7 @@ const ALL_STATUSES: OrderStatus[] = [
   'CANCELLED',
   'REFUNDED',
   'PARTIALLY_REFUNDED',
+  'ON_HOLD',
 ]
 
 const STATUS_VARIANT: Record<OrderStatus, 'default' | 'secondary' | 'outline' | 'destructive'> = {
@@ -77,6 +79,7 @@ const STATUS_VARIANT: Record<OrderStatus, 'default' | 'secondary' | 'outline' | 
   CANCELLED: 'destructive',
   REFUNDED: 'outline',
   PARTIALLY_REFUNDED: 'outline',
+  ON_HOLD: 'destructive',
 }
 
 const PAGE_LIMIT = 20

--- a/apps/web/src/app/[locale]/admin/orders/_lib/order-transitions.ts
+++ b/apps/web/src/app/[locale]/admin/orders/_lib/order-transitions.ts
@@ -2,14 +2,15 @@ import type { OrderStatus } from '@/lib/api/orders'
 
 // Mirrors the backend state machine whitelist.
 export const ALLOWED_TRANSITIONS: Record<OrderStatus, OrderStatus[]> = {
-  PENDING: ['PAID', 'CANCELLED'],
-  PAID: ['PROCESSING', 'CANCELLED'],
-  PROCESSING: ['SHIPPED', 'CANCELLED'],
-  SHIPPED: ['DELIVERED'],
-  DELIVERED: ['REFUNDED', 'PARTIALLY_REFUNDED'],
+  PENDING: ['PAID', 'CANCELLED', 'ON_HOLD'],
+  PAID: ['PROCESSING', 'CANCELLED', 'ON_HOLD'],
+  PROCESSING: ['SHIPPED', 'CANCELLED', 'ON_HOLD'],
+  SHIPPED: ['DELIVERED', 'ON_HOLD'],
+  DELIVERED: ['REFUNDED', 'PARTIALLY_REFUNDED', 'ON_HOLD'],
   CANCELLED: ['REFUNDED', 'PARTIALLY_REFUNDED'],
   REFUNDED: [],
   PARTIALLY_REFUNDED: [],
+  ON_HOLD: ['REFUNDED', 'PARTIALLY_REFUNDED', 'CANCELLED'],
 }
 
 export const STATUS_VARIANT: Record<
@@ -24,6 +25,7 @@ export const STATUS_VARIANT: Record<
   CANCELLED: 'destructive',
   REFUNDED: 'outline',
   PARTIALLY_REFUNDED: 'outline',
+  ON_HOLD: 'destructive',
 }
 
 export const SHIPPING_CARRIERS = ['USPS', 'FedEx', 'UPS', 'DHL'] as const

--- a/apps/web/src/lib/api/orders.ts
+++ b/apps/web/src/lib/api/orders.ts
@@ -125,6 +125,7 @@ export type OrderStatus =
   | 'CANCELLED'
   | 'REFUNDED'
   | 'PARTIALLY_REFUNDED'
+  | 'ON_HOLD'
 
 export interface AdminOrdersQueryParams {
   page?: number

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -132,6 +132,7 @@ export type OrderStatusForBreakdown =
   | 'CANCELLED'
   | 'REFUNDED'
   | 'PARTIALLY_REFUNDED'
+  | 'ON_HOLD'
 
 export interface OrderStatusBreakdownRow {
   status: OrderStatusForBreakdown


### PR DESCRIPTION
## Why

<!-- What problem does this PR solve? Link to the issue. -->

Closes #

## What changed

<!-- List the key changes. Be specific. -->

-

## How to test

<!-- Steps to verify the change works correctly. -->

1.

## Checklist

- [ ] No `any` types in TypeScript
- [ ] `pnpm lint` passes
- [ ] `pnpm build` passes locally
- [ ] Self-reviewed the diff before opening PR
- [ ] QA: affected `docs/qa/**.md` test cases updated (or N/A — purely internal change)
- [ ] Admin help: if a touched admin form added/removed/renamed any field, the matching `docs/admin-help/**.md` is updated in the same PR (or N/A)
