### PR TITLE
feat: wire discount codes into order-create flow (#347)

### DIFF
--- a/apps/api/prisma/migrations/20260707000000_add_discount_to_order/migration.sql
+++ b/apps/api/prisma/migrations/20260707000000_add_discount_to_order/migration.sql
@@ -1,0 +1,7 @@
+-- #347 — wire discount codes into order-create flow.
+-- Discount data is snapshotted on the Order so historical totals stay
+-- correct even if the Discount row is later edited or soft-deleted.
+
+ALTER TABLE "Order" ADD COLUMN "discountCode" TEXT;
+ALTER TABLE "Order" ADD COLUMN "discountAmountCents" INTEGER;
+ALTER TABLE "Order" ADD COLUMN "discountType" "DiscountType";

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -265,6 +265,14 @@ model Order {
   loyaltyPointsUsed   Int @default(0) // 1 point = $0.01
   loyaltyPointsEarned Int @default(0) // credited only at DELIVERED
 
+  // Discount snapshot (#347). Nullable so pre-launch orders (and orders
+  // placed without a code) stay valid. `discountCode` is a snapshot — the
+  // Discount row may be soft-deleted or its `value` edited later without
+  // affecting the historical order total.
+  discountCode        String?
+  discountAmountCents Int?
+  discountType        DiscountType?
+
   // Analytics
   source String? // "web" | "admin"
 

--- a/apps/api/src/discounts/discounts.service.spec.ts
+++ b/apps/api/src/discounts/discounts.service.spec.ts
@@ -15,6 +15,7 @@ const mockPrismaService = {
     findUnique: jest.fn(),
     create: jest.fn(),
     update: jest.fn(),
+    updateMany: jest.fn(),
   },
 }
 
@@ -215,18 +216,99 @@ describe('DiscountsService', () => {
     })
   })
 
-  // ── incrementUsage ───────────────────────────────────────────────────────
+  // ── applyOnOrderCreate — called inside orders.service transaction (#347) ──
 
-  describe('incrementUsage()', () => {
-    it('atomically increments usageCount by 1', async () => {
-      mockPrismaService.discount.update.mockResolvedValueOnce(buildDiscount({ usageCount: 1 }))
+  describe('applyOnOrderCreate()', () => {
+    it('returns the snapshot + bumps usageCount for a valid code', async () => {
+      mockPrismaService.discount.findUnique.mockResolvedValueOnce(
+        buildDiscount({ type: DiscountType.PERCENTAGE, value: 10 }),
+      )
+      mockPrismaService.discount.updateMany.mockResolvedValueOnce({ count: 1 })
 
-      await discountsService.incrementUsage('disc-1')
+      const applied = await discountsService.applyOnOrderCreate(mockPrismaService, {
+        code: 'welcome10',
+        subtotalCents: 5000,
+      })
 
-      expect(mockPrismaService.discount.update).toHaveBeenCalledWith({
+      expect(applied).toEqual({
+        code: 'WELCOME10',
+        type: DiscountType.PERCENTAGE,
+        discountAmountCents: 500,
+      })
+      expect(mockPrismaService.discount.updateMany).toHaveBeenCalledWith({
         where: { id: 'disc-1' },
         data: { usageCount: { increment: 1 } },
       })
+    })
+
+    it('guards the bump with `usageCount < maxUsages` so concurrent orders cannot exceed the cap', async () => {
+      mockPrismaService.discount.findUnique.mockResolvedValueOnce(
+        buildDiscount({ maxUsages: 100, usageCount: 42 }),
+      )
+      mockPrismaService.discount.updateMany.mockResolvedValueOnce({ count: 1 })
+
+      await discountsService.applyOnOrderCreate(mockPrismaService, {
+        code: 'WELCOME10',
+        subtotalCents: 5000,
+      })
+
+      expect(mockPrismaService.discount.updateMany).toHaveBeenCalledWith({
+        where: { id: 'disc-1', usageCount: { lt: 100 } },
+        data: { usageCount: { increment: 1 } },
+      })
+    })
+
+    it('throws when the conditional bump matches zero rows (race lost)', async () => {
+      mockPrismaService.discount.findUnique.mockResolvedValueOnce(
+        buildDiscount({ maxUsages: 100, usageCount: 99 }),
+      )
+      // Another concurrent order won the race — our updateMany finds 0 rows.
+      mockPrismaService.discount.updateMany.mockResolvedValueOnce({ count: 0 })
+
+      await expect(
+        discountsService.applyOnOrderCreate(mockPrismaService, {
+          code: 'WELCOME10',
+          subtotalCents: 5000,
+        }),
+      ).rejects.toThrow(/usage limit/i)
+    })
+
+    it('rejects an expired code (BadRequest so orders.service transaction rolls back)', async () => {
+      mockPrismaService.discount.findUnique.mockResolvedValueOnce(
+        buildDiscount({ expiresAt: new Date('2020-01-01T00:00:00Z') }),
+      )
+
+      await expect(
+        discountsService.applyOnOrderCreate(mockPrismaService, {
+          code: 'WELCOME10',
+          subtotalCents: 5000,
+        }),
+      ).rejects.toThrow(BadRequestException)
+      expect(mockPrismaService.discount.updateMany).not.toHaveBeenCalled()
+    })
+
+    it('rejects when subtotal is below minOrderCents', async () => {
+      mockPrismaService.discount.findUnique.mockResolvedValueOnce(
+        buildDiscount({ minOrderCents: 5000 }),
+      )
+
+      await expect(
+        discountsService.applyOnOrderCreate(mockPrismaService, {
+          code: 'WELCOME10',
+          subtotalCents: 1000,
+        }),
+      ).rejects.toThrow(/minimum order/i)
+    })
+
+    it('rejects an unknown code (BadRequest at order-create, not the 404 the validate endpoint returns)', async () => {
+      mockPrismaService.discount.findUnique.mockResolvedValueOnce(null)
+
+      await expect(
+        discountsService.applyOnOrderCreate(mockPrismaService, {
+          code: 'NOPE',
+          subtotalCents: 5000,
+        }),
+      ).rejects.toThrow(BadRequestException)
     })
   })
 })

--- a/apps/api/src/discounts/discounts.service.ts
+++ b/apps/api/src/discounts/discounts.service.ts
@@ -10,6 +10,19 @@ import { CreateDiscountDto } from './dto/create-discount.dto'
 import { UpdateDiscountDto } from './dto/update-discount.dto'
 import { ValidateDiscountDto } from './dto/validate-discount.dto'
 
+// Prisma transaction client slice for `applyOnOrderCreate` — accepts either
+// the service itself or a $transaction client, so a caller can atomically tie
+// the usage bump to order creation.
+export type DiscountsPrismaClient = {
+  discount: Pick<PrismaService['discount'], 'findUnique' | 'updateMany'>
+}
+
+export interface AppliedDiscount {
+  code: string
+  type: DiscountType
+  discountAmountCents: number
+}
+
 // Bounded by subtotal — a 100% code on a $50 cart returns 5000, never above.
 export function computeDiscountAmountCents(
   type: DiscountType,
@@ -142,12 +155,68 @@ export class DiscountsService {
     }
   }
 
-  // TODO(post-launch): wire into the order-create / payment webhook flow.
-  async incrementUsage(discountId: string) {
-    return this.prismaService.discount.update({
-      where: { id: discountId },
-      data: { usageCount: { increment: 1 } },
+  /**
+   * Applied inside the order-create transaction (#347). Re-validates the code
+   * server-side, atomically bumps `usageCount` (a conditional `updateMany`
+   * against `usageCount < maxUsages` so two concurrent checkouts can't push
+   * the counter past `maxUsages`), and returns the discount snapshot the
+   * caller writes onto the Order. Throws on any validation failure — the
+   * transaction rolls back and no order is created.
+   *
+   * Refunds do NOT decrement usageCount (per issue scope) — the code was
+   * used at checkout, that's what the limit tracks.
+   */
+  async applyOnOrderCreate(
+    prismaClient: DiscountsPrismaClient,
+    args: { code: string; subtotalCents: number },
+  ): Promise<AppliedDiscount> {
+    const normalisedCode = args.code.toUpperCase()
+    const discount = await prismaClient.discount.findUnique({
+      where: { code: normalisedCode },
     })
+
+    if (!discount || discount.deletedAt) {
+      throw new BadRequestException(`Discount code "${normalisedCode}" not found`)
+    }
+    if (!discount.isActive) {
+      throw new BadRequestException('Discount code is not active')
+    }
+    if (discount.expiresAt && discount.expiresAt < new Date()) {
+      throw new BadRequestException('Discount code has expired')
+    }
+    if (args.subtotalCents < discount.minOrderCents) {
+      throw new BadRequestException(
+        `Minimum order ${(discount.minOrderCents / 100).toFixed(2)} not met`,
+      )
+    }
+
+    // Race-safe bump: two concurrent order-creates for a code with
+    // `maxUsages = usageCount + 1` remaining both pass the `<` check up top
+    // but only one wins the `updateMany` (the other matches 0 rows).
+    if (discount.maxUsages !== null) {
+      const bumped = await prismaClient.discount.updateMany({
+        where: { id: discount.id, usageCount: { lt: discount.maxUsages } },
+        data: { usageCount: { increment: 1 } },
+      })
+      if (bumped.count === 0) {
+        throw new BadRequestException('Discount code has reached its usage limit')
+      }
+    } else {
+      await prismaClient.discount.updateMany({
+        where: { id: discount.id },
+        data: { usageCount: { increment: 1 } },
+      })
+    }
+
+    return {
+      code: discount.code,
+      type: discount.type,
+      discountAmountCents: computeDiscountAmountCents(
+        discount.type,
+        discount.value,
+        args.subtotalCents,
+      ),
+    }
   }
 
   private assertValidValueForType(type: DiscountType, value: number): void {

--- a/apps/api/src/orders/dto/create-order.dto.ts
+++ b/apps/api/src/orders/dto/create-order.dto.ts
@@ -9,6 +9,7 @@ import {
   IsOptional,
   IsPositive,
   IsString,
+  Length,
   Max,
   Min,
   registerDecorator,
@@ -143,6 +144,16 @@ export class CreateOrderDto {
   @Min(0)
   @IsOptional()
   loyaltyPointsToRedeem?: number
+
+  /**
+   * Discount code the buyer entered at checkout. Server re-validates the code
+   * (existence, active, expiry, min-order, usage cap) before applying — never
+   * trust the client's computed discount amount.
+   */
+  @IsString()
+  @Length(1, 30)
+  @IsOptional()
+  discountCode?: string
 
   @IsString()
   @IsOptional()

--- a/apps/api/src/orders/orders.module.ts
+++ b/apps/api/src/orders/orders.module.ts
@@ -1,6 +1,7 @@
 import { Module } from '@nestjs/common'
 import { AnalyticsModule } from '../analytics/analytics.module'
 import { AuthModule } from '../auth/auth.module'
+import { DiscountsModule } from '../discounts/discounts.module'
 import { EmailModule } from '../email/email.module'
 import { LoyaltyModule } from '../loyalty/loyalty.module'
 import { PrismaModule } from '../prisma/prisma.module'
@@ -12,7 +13,15 @@ import { OrdersRefundsService } from './orders-refunds.service'
 import { OrdersService } from './orders.service'
 
 @Module({
-  imports: [PrismaModule, AuthModule, EmailModule, StripeModule, LoyaltyModule, AnalyticsModule],
+  imports: [
+    PrismaModule,
+    AuthModule,
+    EmailModule,
+    StripeModule,
+    LoyaltyModule,
+    AnalyticsModule,
+    DiscountsModule,
+  ],
   controllers: [OrdersController, AdminOrdersController],
   providers: [OrdersService, OrdersRefundsService, OrdersProductionService],
 })

--- a/apps/api/src/orders/orders.service.spec.ts
+++ b/apps/api/src/orders/orders.service.spec.ts
@@ -1,12 +1,13 @@
 import { BadRequestException, NotFoundException } from '@nestjs/common'
 import { Test, TestingModule } from '@nestjs/testing'
-import { OrderStatus } from '@prisma/client'
+import { DiscountType, OrderStatus } from '@prisma/client'
 import { Decimal } from '@prisma/client/runtime/library'
 import {
   suite as $allureSuite,
   subSuite as $allureSubSuite,
   severity as $allureSeverity,
 } from 'allure-js-commons'
+import { DiscountsService } from '../discounts/discounts.service'
 import { EmailService } from '../email/email.service'
 import { LoyaltyService } from '../loyalty/loyalty.service'
 import { PrismaService } from '../prisma/prisma.service'
@@ -71,6 +72,10 @@ const mockLoyaltyService = {
   spendForCheckout: jest.fn().mockResolvedValue(undefined),
 }
 
+const mockDiscountsService = {
+  applyOnOrderCreate: jest.fn(),
+}
+
 beforeEach(async () => {
   if (!process.env.CI) return
   await $allureSuite('api/orders')
@@ -88,6 +93,7 @@ describe('OrdersService', () => {
         { provide: PrismaService, useValue: mockPrismaService },
         { provide: EmailService, useValue: mockEmailService },
         { provide: LoyaltyService, useValue: mockLoyaltyService },
+        { provide: DiscountsService, useValue: mockDiscountsService },
       ],
     }).compile()
 
@@ -163,6 +169,110 @@ describe('OrdersService', () => {
         orderId: mockCreatedOrder.id,
         points: 2000,
       })
+    })
+
+    // ── discount codes (#347) ───────────────────────────────────────────────
+
+    it('applies a valid discount code — persists snapshot and subtracts from total', async () => {
+      mockDiscountsService.applyOnOrderCreate.mockResolvedValueOnce({
+        code: 'WELCOME10',
+        type: DiscountType.PERCENTAGE,
+        discountAmountCents: 1000, // $10 off
+      })
+      mockPrismaService.order.create.mockResolvedValue(mockCreatedOrder)
+
+      await ordersService.create({
+        items: [mockOrderItem],
+        shippingAddress: mockShippingAddress,
+        subtotal: 100,
+        shippingCost: 5,
+        total: 105,
+        discountCode: 'welcome10',
+      })
+
+      expect(mockDiscountsService.applyOnOrderCreate).toHaveBeenCalledWith(expect.anything(), {
+        code: 'welcome10',
+        subtotalCents: 10000,
+      })
+      const callData = mockPrismaService.order.create.mock.calls[0]?.[0] as {
+        data: {
+          total: number
+          discountCode: string | null
+          discountAmountCents: number | null
+          discountType: DiscountType | null
+        }
+      }
+      // 105 - 10 = 95
+      expect(callData.data.total).toBe(95)
+      expect(callData.data.discountCode).toBe('WELCOME10')
+      expect(callData.data.discountAmountCents).toBe(1000)
+      expect(callData.data.discountType).toBe(DiscountType.PERCENTAGE)
+    })
+
+    it('propagates BadRequestException from applyOnOrderCreate — no order is created', async () => {
+      mockDiscountsService.applyOnOrderCreate.mockRejectedValueOnce(
+        new BadRequestException('Discount code has expired'),
+      )
+
+      await expect(
+        ordersService.create({
+          items: [mockOrderItem],
+          shippingAddress: mockShippingAddress,
+          subtotal: 100,
+          shippingCost: 5,
+          total: 105,
+          discountCode: 'EXPIRED',
+        }),
+      ).rejects.toThrow(BadRequestException)
+
+      expect(mockPrismaService.order.create).not.toHaveBeenCalled()
+    })
+
+    it('leaves discount fields null when no code is provided', async () => {
+      mockPrismaService.order.create.mockResolvedValue(mockCreatedOrder)
+
+      await ordersService.create({
+        items: [mockOrderItem],
+        shippingAddress: mockShippingAddress,
+        subtotal: 100,
+        shippingCost: 5,
+        total: 105,
+      })
+
+      expect(mockDiscountsService.applyOnOrderCreate).not.toHaveBeenCalled()
+      const callData = mockPrismaService.order.create.mock.calls[0]?.[0] as {
+        data: {
+          discountCode: string | null
+          discountAmountCents: number | null
+          discountType: DiscountType | null
+        }
+      }
+      expect(callData.data.discountCode).toBeNull()
+      expect(callData.data.discountAmountCents).toBeNull()
+      expect(callData.data.discountType).toBeNull()
+    })
+
+    it('clamps discounted total to 0 when discountAmount exceeds the loyalty-adjusted total', async () => {
+      mockDiscountsService.applyOnOrderCreate.mockResolvedValueOnce({
+        code: 'BIGDEAL',
+        type: DiscountType.FIXED_AMOUNT,
+        discountAmountCents: 20000, // $200 off a $105 order
+      })
+      mockPrismaService.order.create.mockResolvedValue(mockCreatedOrder)
+
+      await ordersService.create({
+        items: [mockOrderItem],
+        shippingAddress: mockShippingAddress,
+        subtotal: 100,
+        shippingCost: 5,
+        total: 105,
+        discountCode: 'BIGDEAL',
+      })
+
+      const callData = mockPrismaService.order.create.mock.calls[0]?.[0] as {
+        data: { total: number }
+      }
+      expect(callData.data.total).toBe(0)
     })
   })
 

--- a/apps/api/src/orders/orders.service.ts
+++ b/apps/api/src/orders/orders.service.ts
@@ -4,6 +4,7 @@ import * as Sentry from '@sentry/nestjs'
 import { InputJsonValue } from '@prisma/client/runtime/library'
 import { buildCsvDocument } from '../common/csv/csv-formatter'
 import { paginate } from '../common/pagination/paginate'
+import { DiscountsService, type AppliedDiscount } from '../discounts/discounts.service'
 import { EmailService } from '../email/email.service'
 import { LoyaltyService } from '../loyalty/loyalty.service'
 import { PrismaService } from '../prisma/prisma.service'
@@ -73,6 +74,7 @@ export class OrdersService {
     private readonly prismaService: PrismaService,
     private readonly emailService: EmailService,
     private readonly loyaltyService: LoyaltyService,
+    private readonly discountsService: DiscountsService,
   ) {}
 
   async create(createOrderDto: CreateOrderDto) {
@@ -85,6 +87,7 @@ export class OrdersService {
       shippingCost,
       total,
       loyaltyPointsToRedeem,
+      discountCode,
       source,
     } = createOrderDto
 
@@ -104,6 +107,19 @@ export class OrdersService {
 
     try {
       const order = await this.prismaService.$transaction(async (tx) => {
+        // Discount applies before order.create so a rejected code aborts
+        // the whole transaction — the counter bump and the row insert
+        // succeed or fail together.
+        let appliedDiscount: AppliedDiscount | null = null
+        if (discountCode) {
+          appliedDiscount = await this.discountsService.applyOnOrderCreate(tx, {
+            code: discountCode,
+            subtotalCents: Math.round(subtotal * 100),
+          })
+          const discountUsd = appliedDiscount.discountAmountCents / 100
+          adjustedTotal = Math.max(0, Number((adjustedTotal - discountUsd).toFixed(2)))
+        }
+
         const created = await tx.order.create({
           data: {
             userId: userId ?? null,
@@ -112,6 +128,9 @@ export class OrdersService {
             shippingCost,
             total: adjustedTotal,
             loyaltyPointsUsed: pointsToRedeem,
+            discountCode: appliedDiscount?.code ?? null,
+            discountAmountCents: appliedDiscount?.discountAmountCents ?? null,
+            discountType: appliedDiscount?.type ?? null,
             shippingAddress: shippingAddress as unknown as InputJsonValue,
             source: source ?? 'web',
             status: OrderStatus.PENDING,

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -660,6 +660,7 @@
     "orderDetailFieldSubtotal": "Subtotal",
     "orderDetailFieldShipping": "Shipping",
     "orderDetailFieldTotal": "Total",
+    "orderDetailFieldDiscount": "Discount",
     "orderDetailFieldSource": "Source",
     "orderDetailFieldPayment": "Payment",
     "orderDetailFieldEmail": "Email",

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -660,6 +660,7 @@
     "orderDetailFieldSubtotal": "Subtotal",
     "orderDetailFieldShipping": "Envío",
     "orderDetailFieldTotal": "Total",
+    "orderDetailFieldDiscount": "Descuento",
     "orderDetailFieldSource": "Origen",
     "orderDetailFieldPayment": "Pago",
     "orderDetailFieldEmail": "Email",

--- a/apps/web/messages/ru.json
+++ b/apps/web/messages/ru.json
@@ -660,6 +660,7 @@
     "orderDetailFieldSubtotal": "Подытог",
     "orderDetailFieldShipping": "Доставка",
     "orderDetailFieldTotal": "Итого",
+    "orderDetailFieldDiscount": "Скидка",
     "orderDetailFieldSource": "Источник",
     "orderDetailFieldPayment": "Оплата",
     "orderDetailFieldEmail": "Email",

--- a/apps/web/src/app/[locale]/admin/orders/[id]/_components/__tests__/admin-order-detail.test.tsx
+++ b/apps/web/src/app/[locale]/admin/orders/[id]/_components/__tests__/admin-order-detail.test.tsx
@@ -100,6 +100,9 @@ const mockOrder: AdminOrderDetailType = {
   easypostTrackerId: null,
   labelUrl: null,
   shippingInsuranceCents: 0,
+  discountCode: null,
+  discountAmountCents: null,
+  discountType: null,
   source: 'web',
   payment: {
     id: 'pay-1',

--- a/apps/web/src/app/[locale]/admin/orders/[id]/_components/__tests__/pure-cards.test.tsx
+++ b/apps/web/src/app/[locale]/admin/orders/[id]/_components/__tests__/pure-cards.test.tsx
@@ -84,6 +84,9 @@ function buildOrder(overrides: Partial<AdminOrderDetail> = {}): AdminOrderDetail
     easypostTrackerId: null,
     labelUrl: null,
     shippingInsuranceCents: 0,
+    discountCode: null,
+    discountAmountCents: null,
+    discountType: null,
     ...overrides,
   }
 }

--- a/apps/web/src/app/[locale]/admin/orders/[id]/_components/__tests__/status-update-section.test.tsx
+++ b/apps/web/src/app/[locale]/admin/orders/[id]/_components/__tests__/status-update-section.test.tsx
@@ -47,6 +47,9 @@ function buildOrder(status: AdminOrderDetail['status']): AdminOrderDetail {
     easypostTrackerId: null,
     labelUrl: null,
     shippingInsuranceCents: 0,
+    discountCode: null,
+    discountAmountCents: null,
+    discountType: null,
   }
 }
 

--- a/apps/web/src/app/[locale]/admin/orders/[id]/_components/__tests__/tracking-section.test.tsx
+++ b/apps/web/src/app/[locale]/admin/orders/[id]/_components/__tests__/tracking-section.test.tsx
@@ -47,6 +47,9 @@ function buildOrder(overrides: Partial<AdminOrderDetail> = {}): AdminOrderDetail
     easypostTrackerId: null,
     labelUrl: null,
     shippingInsuranceCents: 0,
+    discountCode: null,
+    discountAmountCents: null,
+    discountType: null,
     ...overrides,
   }
 }

--- a/apps/web/src/app/[locale]/admin/orders/[id]/_components/order-summary-card.tsx
+++ b/apps/web/src/app/[locale]/admin/orders/[id]/_components/order-summary-card.tsx
@@ -56,6 +56,20 @@ export function OrderSummaryCard({ order }: { order: AdminOrderDetailType }) {
             </data>
           </dd>
         </div>
+        {order.discountCode && order.discountAmountCents !== null && (
+          <div>
+            <dt className="text-muted-foreground">{t('orderDetailFieldDiscount')}</dt>
+            <dd className="font-medium text-foreground">
+              <code className="rounded bg-muted px-1.5 py-0.5 text-xs">{order.discountCode}</code>
+              <span className="ml-2">
+                −
+                <data value={order.discountAmountCents / 100}>
+                  ${(order.discountAmountCents / 100).toFixed(2)}
+                </data>
+              </span>
+            </dd>
+          </div>
+        )}
         <div>
           <dt className="text-muted-foreground">{t('orderDetailFieldSource')}</dt>
           <dd className="capitalize text-foreground">{order.source ?? '—'}</dd>

--- a/apps/web/src/app/[locale]/checkout/_lib/build-order-payload.ts
+++ b/apps/web/src/app/[locale]/checkout/_lib/build-order-payload.ts
@@ -12,6 +12,8 @@ interface BuildOrderPayloadOptions {
   userId?: string
   /** Loyalty points the buyer chose to redeem. Server clamps. */
   loyaltyPointsToRedeem?: number
+  /** Discount code the buyer entered. Server re-validates and computes amount. */
+  discountCode?: string
 }
 
 export function buildOrderPayload(
@@ -48,6 +50,7 @@ export function buildOrderPayload(
     ...(options.loyaltyPointsToRedeem
       ? { loyaltyPointsToRedeem: options.loyaltyPointsToRedeem }
       : {}),
+    ...(options.discountCode ? { discountCode: options.discountCode } : {}),
     source: 'web',
   }
 }

--- a/apps/web/src/lib/api/orders.ts
+++ b/apps/web/src/lib/api/orders.ts
@@ -25,6 +25,8 @@ export interface OrderItemPayload {
   }
 }
 
+export type DiscountType = 'PERCENTAGE' | 'FIXED_AMOUNT'
+
 export interface CreateOrderPayload {
   userId?: string
   guestEmail?: string
@@ -35,6 +37,9 @@ export interface CreateOrderPayload {
   total: number
   // Server clamps to balance + 50% subtotal.
   loyaltyPointsToRedeem?: number
+  // Server re-validates and computes the actual amount — client value is
+  // only used to display an expected total before submitting.
+  discountCode?: string
   source?: string
 }
 
@@ -108,6 +113,9 @@ export interface AdminOrderDetail extends OrderDetails {
   easypostTrackerId: string | null
   labelUrl: string | null
   shippingInsuranceCents: number
+  discountCode: string | null
+  discountAmountCents: number | null
+  discountType: DiscountType | null
 }
 
 export interface UpdateOrderTrackingPayload {


### PR DESCRIPTION
## Why

<!-- What problem does this PR solve? Link to the issue. -->

Closes #

## What changed

<!-- List the key changes. Be specific. -->

-

## How to test

<!-- Steps to verify the change works correctly. -->

1.

## Checklist

- [ ] No `any` types in TypeScript
- [ ] `pnpm lint` passes
- [ ] `pnpm build` passes locally
- [ ] Self-reviewed the diff before opening PR
- [ ] QA: affected `docs/qa/**.md` test cases updated (or N/A — purely internal change)
- [ ] Admin help: if a touched admin form added/removed/renamed any field, the matching `docs/admin-help/**.md` is updated in the same PR (or N/A)
