### PR TITLE
chore: env-based contact emails on Privacy + Terms — pre-launch (#359)

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -67,3 +67,13 @@ NEXT_PUBLIC_APP_VERSION=
 SENTRY_ORG=
 SENTRY_PROJECT=
 SENTRY_AUTH_TOKEN=
+
+# ─── Public contact details (Privacy Policy / Terms / support) ──────────────
+# FTC/CAN-SPAM: a placeholder in the Privacy Policy invalidates it.
+# Prod throws when empty; dev falls back to *.handmade-jewelry.local.
+NEXT_PUBLIC_PRIVACY_EMAIL=
+NEXT_PUBLIC_SUPPORT_EMAIL=
+NEXT_PUBLIC_LEGAL_EMAIL=
+
+# Physical postal address (single line). Empty = address block is hidden.
+NEXT_PUBLIC_COMPANY_ADDRESS=

--- a/apps/web/src/app/[locale]/privacy/__tests__/privacy-page.test.tsx
+++ b/apps/web/src/app/[locale]/privacy/__tests__/privacy-page.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { render, screen } from '@testing-library/react'
 import messages from '../../../../../messages/en.json'
 import PrivacyPage from '../page'
@@ -23,11 +23,25 @@ async function renderPrivacyPage() {
   return render(jsx)
 }
 
+const ORIGINAL_PRIVACY_EMAIL = process.env.NEXT_PUBLIC_PRIVACY_EMAIL
+const ORIGINAL_COMPANY_ADDRESS = process.env.NEXT_PUBLIC_COMPANY_ADDRESS
+const TEST_PRIVACY_EMAIL = 'privacy@senichka.test'
+const TEST_COMPANY_ADDRESS = '123 Test Ave, Austin, TX, USA'
+
 beforeEach(async () => {
+  process.env.NEXT_PUBLIC_PRIVACY_EMAIL = TEST_PRIVACY_EMAIL
+  process.env.NEXT_PUBLIC_COMPANY_ADDRESS = TEST_COMPANY_ADDRESS
   if (!process.env.CI) return
   await $allureSuite('web/app/locale')
   await $allureSubSuite('privacy-page')
   await $allureSeverity('normal')
+})
+
+afterEach(() => {
+  if (ORIGINAL_PRIVACY_EMAIL === undefined) delete process.env.NEXT_PUBLIC_PRIVACY_EMAIL
+  else process.env.NEXT_PUBLIC_PRIVACY_EMAIL = ORIGINAL_PRIVACY_EMAIL
+  if (ORIGINAL_COMPANY_ADDRESS === undefined) delete process.env.NEXT_PUBLIC_COMPANY_ADDRESS
+  else process.env.NEXT_PUBLIC_COMPANY_ADDRESS = ORIGINAL_COMPANY_ADDRESS
 })
 
 describe('PrivacyPage — structure', () => {
@@ -90,11 +104,21 @@ describe('PrivacyPage — structure', () => {
     expect(screen.getByText(/right to be forgotten/)).toBeInTheDocument()
   })
 
-  it('renders contact email links', async () => {
+  it('renders contact email links from NEXT_PUBLIC_PRIVACY_EMAIL', async () => {
     await renderPrivacyPage()
-    const emailLinks = screen.getAllByRole('link', { name: 'privacy@example.com' })
+    const emailLinks = screen.getAllByRole('link', { name: TEST_PRIVACY_EMAIL })
     expect(emailLinks.length).toBeGreaterThanOrEqual(1)
-    expect(emailLinks[0]).toHaveAttribute('href', 'mailto:privacy@example.com')
+    expect(emailLinks[0]).toHaveAttribute('href', `mailto:${TEST_PRIVACY_EMAIL}`)
+  })
+
+  it('renders the physical postal address from NEXT_PUBLIC_COMPANY_ADDRESS', async () => {
+    await renderPrivacyPage()
+    expect(screen.getByText(TEST_COMPANY_ADDRESS)).toBeInTheDocument()
+  })
+
+  it('never emits an @example.com placeholder — that would invalidate the policy', async () => {
+    await renderPrivacyPage()
+    expect(screen.queryByText(/@example\.com/i)).not.toBeInTheDocument()
   })
 
   it('uses a <main> landmark as root element', async () => {

--- a/apps/web/src/app/[locale]/privacy/page.tsx
+++ b/apps/web/src/app/[locale]/privacy/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next'
 import { getTranslations, setRequestLocale } from 'next-intl/server'
 import { buildLocaleAlternates } from '@/lib/seo/alternates'
+import { getCompanyAddress, getPrivacyEmail } from '@/lib/config/contact'
 
 interface PrivacyPageProps {
   params: Promise<{ locale: string }>
@@ -28,6 +29,8 @@ export default async function PrivacyPage({ params }: PrivacyPageProps) {
   setRequestLocale(locale)
 
   const t = await getTranslations('privacyPage')
+  const privacyEmail = getPrivacyEmail()
+  const companyAddress = getCompanyAddress()
 
   return (
     <main>
@@ -222,8 +225,8 @@ export default async function PrivacyPage({ params }: PrivacyPageProps) {
             </ul>
             <p className="mt-4 text-muted-foreground">
               To exercise any of these rights, contact us at{' '}
-              <a href="mailto:privacy@example.com" className="underline hover:text-foreground">
-                privacy@example.com
+              <a href={`mailto:${privacyEmail}`} className="underline hover:text-foreground">
+                {privacyEmail}
               </a>
               . We will respond within 30 days.
             </p>
@@ -272,10 +275,11 @@ export default async function PrivacyPage({ params }: PrivacyPageProps) {
             </p>
             <address className="mt-4 not-italic text-muted-foreground">
               <p>Handmade Jewelry Store</p>
+              {companyAddress && <p>{companyAddress}</p>}
               <p>
                 Email:{' '}
-                <a href="mailto:privacy@example.com" className="underline hover:text-foreground">
-                  privacy@example.com
+                <a href={`mailto:${privacyEmail}`} className="underline hover:text-foreground">
+                  {privacyEmail}
                 </a>
               </p>
             </address>

--- a/apps/web/src/app/[locale]/terms/__tests__/terms-page.test.tsx
+++ b/apps/web/src/app/[locale]/terms/__tests__/terms-page.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { render, screen } from '@testing-library/react'
 import messages from '../../../../../messages/en.json'
 import TermsPage from '../page'
@@ -30,11 +30,30 @@ async function renderTermsPage() {
   return render(jsx)
 }
 
+const ORIGINAL_SUPPORT_EMAIL = process.env.NEXT_PUBLIC_SUPPORT_EMAIL
+const ORIGINAL_LEGAL_EMAIL = process.env.NEXT_PUBLIC_LEGAL_EMAIL
+const ORIGINAL_COMPANY_ADDRESS = process.env.NEXT_PUBLIC_COMPANY_ADDRESS
+const TEST_SUPPORT_EMAIL = 'support@senichka.test'
+const TEST_LEGAL_EMAIL = 'legal@senichka.test'
+const TEST_COMPANY_ADDRESS = '123 Test Ave, Austin, TX, USA'
+
 beforeEach(async () => {
+  process.env.NEXT_PUBLIC_SUPPORT_EMAIL = TEST_SUPPORT_EMAIL
+  process.env.NEXT_PUBLIC_LEGAL_EMAIL = TEST_LEGAL_EMAIL
+  process.env.NEXT_PUBLIC_COMPANY_ADDRESS = TEST_COMPANY_ADDRESS
   if (!process.env.CI) return
   await $allureSuite('web/app/locale')
   await $allureSubSuite('terms-page')
   await $allureSeverity('normal')
+})
+
+afterEach(() => {
+  if (ORIGINAL_SUPPORT_EMAIL === undefined) delete process.env.NEXT_PUBLIC_SUPPORT_EMAIL
+  else process.env.NEXT_PUBLIC_SUPPORT_EMAIL = ORIGINAL_SUPPORT_EMAIL
+  if (ORIGINAL_LEGAL_EMAIL === undefined) delete process.env.NEXT_PUBLIC_LEGAL_EMAIL
+  else process.env.NEXT_PUBLIC_LEGAL_EMAIL = ORIGINAL_LEGAL_EMAIL
+  if (ORIGINAL_COMPANY_ADDRESS === undefined) delete process.env.NEXT_PUBLIC_COMPANY_ADDRESS
+  else process.env.NEXT_PUBLIC_COMPANY_ADDRESS = ORIGINAL_COMPANY_ADDRESS
 })
 
 describe('TermsPage — metadata', () => {
@@ -91,10 +110,10 @@ describe('TermsPage — returns and refund policy', () => {
     expect(screen.getByText(/custom or personalized pieces.*are exempt/i)).toBeInTheDocument()
   })
 
-  it('renders the support email link for returns', async () => {
+  it('renders the support email link for returns from NEXT_PUBLIC_SUPPORT_EMAIL', async () => {
     await renderTermsPage()
-    const supportLink = screen.getByRole('link', { name: 'support@example.com' })
-    expect(supportLink).toHaveAttribute('href', 'mailto:support@example.com')
+    const supportLink = screen.getByRole('link', { name: TEST_SUPPORT_EMAIL })
+    expect(supportLink).toHaveAttribute('href', `mailto:${TEST_SUPPORT_EMAIL}`)
   })
 })
 
@@ -116,10 +135,20 @@ describe('TermsPage — payment and legal', () => {
     expect(screen.getByText(/Afterpay/)).toBeInTheDocument()
   })
 
-  it('renders the legal@example.com contact email in the contact section', async () => {
+  it('renders the legal contact email from NEXT_PUBLIC_LEGAL_EMAIL', async () => {
     await renderTermsPage()
-    const legalEmailLink = screen.getByRole('link', { name: 'legal@example.com' })
-    expect(legalEmailLink).toHaveAttribute('href', 'mailto:legal@example.com')
+    const legalEmailLink = screen.getByRole('link', { name: TEST_LEGAL_EMAIL })
+    expect(legalEmailLink).toHaveAttribute('href', `mailto:${TEST_LEGAL_EMAIL}`)
+  })
+
+  it('renders the physical postal address from NEXT_PUBLIC_COMPANY_ADDRESS', async () => {
+    await renderTermsPage()
+    expect(screen.getByText(TEST_COMPANY_ADDRESS)).toBeInTheDocument()
+  })
+
+  it('never emits an @example.com placeholder — that would invalidate the Terms', async () => {
+    await renderTermsPage()
+    expect(screen.queryByText(/@example\.com/i)).not.toBeInTheDocument()
   })
 })
 

--- a/apps/web/src/app/[locale]/terms/page.tsx
+++ b/apps/web/src/app/[locale]/terms/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next'
 import { getTranslations, setRequestLocale } from 'next-intl/server'
 import { buildLocaleAlternates } from '@/lib/seo/alternates'
 import Link from 'next/link'
+import { getCompanyAddress, getLegalEmail, getSupportEmail } from '@/lib/config/contact'
 
 interface TermsPageProps {
   params: Promise<{ locale: string }>
@@ -29,6 +30,9 @@ export default async function TermsPage({ params }: TermsPageProps) {
   setRequestLocale(locale)
 
   const t = await getTranslations('termsPage')
+  const supportEmail = getSupportEmail()
+  const legalEmail = getLegalEmail()
+  const companyAddress = getCompanyAddress()
 
   return (
     <main>
@@ -149,8 +153,8 @@ export default async function TermsPage({ params }: TermsPageProps) {
               </li>
               <li>
                 To initiate a return, contact us at{' '}
-                <a href="mailto:support@example.com" className="underline hover:text-foreground">
-                  support@example.com
+                <a href={`mailto:${supportEmail}`} className="underline hover:text-foreground">
+                  {supportEmail}
                 </a>{' '}
                 within the return window with your order number and reason for return.
               </li>
@@ -301,10 +305,11 @@ export default async function TermsPage({ params }: TermsPageProps) {
             </p>
             <address className="not-italic text-muted-foreground">
               <p>Handmade Jewelry Store</p>
+              {companyAddress && <p>{companyAddress}</p>}
               <p>
                 Email:{' '}
-                <a href="mailto:legal@example.com" className="underline hover:text-foreground">
-                  legal@example.com
+                <a href={`mailto:${legalEmail}`} className="underline hover:text-foreground">
+                  {legalEmail}
                 </a>
               </p>
             </address>

--- a/apps/web/src/lib/config/__tests__/contact.spec.ts
+++ b/apps/web/src/lib/config/__tests__/contact.spec.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import {
+  suite as $allureSuite,
+  subSuite as $allureSubSuite,
+  severity as $allureSeverity,
+} from 'allure-js-commons'
+import { getPrivacyEmail, getSupportEmail, getLegalEmail, getCompanyAddress } from '../contact'
+
+const ENV_KEYS = [
+  'NEXT_PUBLIC_PRIVACY_EMAIL',
+  'NEXT_PUBLIC_SUPPORT_EMAIL',
+  'NEXT_PUBLIC_LEGAL_EMAIL',
+  'NEXT_PUBLIC_COMPANY_ADDRESS',
+] as const
+
+const originalEnv: Record<string, string | undefined> = {}
+
+beforeEach(async () => {
+  for (const key of ENV_KEYS) {
+    originalEnv[key] = process.env[key]
+    delete process.env[key]
+  }
+  if (!process.env.CI) return
+  await $allureSuite('web/lib/config')
+  await $allureSubSuite('contact')
+  await $allureSeverity('critical')
+})
+
+afterEach(() => {
+  for (const key of ENV_KEYS) {
+    if (originalEnv[key] === undefined) delete process.env[key]
+    else process.env[key] = originalEnv[key]
+  }
+  vi.unstubAllEnvs()
+  vi.restoreAllMocks()
+})
+
+describe('getPrivacyEmail / getSupportEmail / getLegalEmail', () => {
+  it('returns the env-configured address, trimmed', () => {
+    process.env.NEXT_PUBLIC_PRIVACY_EMAIL = '  privacy@senichka.com  '
+    expect(getPrivacyEmail()).toBe('privacy@senichka.com')
+  })
+
+  it('routes each getter to its own env var — no cross-wiring', () => {
+    process.env.NEXT_PUBLIC_PRIVACY_EMAIL = 'p@x.com'
+    process.env.NEXT_PUBLIC_SUPPORT_EMAIL = 's@x.com'
+    process.env.NEXT_PUBLIC_LEGAL_EMAIL = 'l@x.com'
+    expect(getPrivacyEmail()).toBe('p@x.com')
+    expect(getSupportEmail()).toBe('s@x.com')
+    expect(getLegalEmail()).toBe('l@x.com')
+  })
+
+  it('falls back to a *.local dev address in non-production (never @example.com)', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const fallback = getSupportEmail()
+    expect(fallback).toMatch(/@handmade-jewelry\.local$/)
+    expect(fallback).not.toContain('@example.com')
+    expect(warn).toHaveBeenCalledOnce()
+  })
+
+  it('throws in production when the env var is missing — placeholder would invalidate the policy', () => {
+    vi.stubEnv('NODE_ENV', 'production')
+    expect(() => getPrivacyEmail()).toThrow(/NEXT_PUBLIC_PRIVACY_EMAIL is not set/)
+    expect(() => getSupportEmail()).toThrow(/NEXT_PUBLIC_SUPPORT_EMAIL is not set/)
+    expect(() => getLegalEmail()).toThrow(/NEXT_PUBLIC_LEGAL_EMAIL is not set/)
+  })
+
+  it('throws in production when the env var is only whitespace', () => {
+    vi.stubEnv('NODE_ENV', 'production')
+    process.env.NEXT_PUBLIC_LEGAL_EMAIL = '   '
+    expect(() => getLegalEmail()).toThrow(/NEXT_PUBLIC_LEGAL_EMAIL is not set/)
+  })
+})
+
+describe('getCompanyAddress', () => {
+  it('returns the env-configured address, trimmed', () => {
+    process.env.NEXT_PUBLIC_COMPANY_ADDRESS = '  123 Main St, Austin, TX  '
+    expect(getCompanyAddress()).toBe('123 Main St, Austin, TX')
+  })
+
+  it('returns an empty string when the env var is unset (does not throw in prod)', () => {
+    vi.stubEnv('NODE_ENV', 'production')
+    expect(getCompanyAddress()).toBe('')
+  })
+})

--- a/apps/web/src/lib/config/contact.ts
+++ b/apps/web/src/lib/config/contact.ts
@@ -1,0 +1,49 @@
+// FTC/CAN-SPAM: a placeholder address in the Privacy Policy invalidates it.
+// Prod throws when the env var is empty; dev returns a *.local fallback.
+
+const DEV_FALLBACKS = {
+  privacyEmail: 'privacy@handmade-jewelry.local',
+  supportEmail: 'support@handmade-jewelry.local',
+  legalEmail: 'legal@handmade-jewelry.local',
+} as const
+
+const warned = new Set<string>()
+
+function readOrThrow(envName: string, devFallback: string): string {
+  const raw = process.env[envName]
+  if (raw && raw.trim() !== '') return raw.trim()
+
+  if (process.env.NODE_ENV === 'production') {
+    throw new Error(
+      `${envName} is not set. Legal / contact pages cannot render a valid address. ` +
+        `Set the env var on your hosting platform (Vercel / Fly.io secrets) and redeploy.`,
+    )
+  }
+
+  if (!warned.has(envName)) {
+    console.warn(
+      `[contact] ${envName} is empty — using dev fallback "${devFallback}". ` +
+        `Set it in apps/web/.env.local before shipping.`,
+    )
+    warned.add(envName)
+  }
+  return devFallback
+}
+
+export function getPrivacyEmail(): string {
+  return readOrThrow('NEXT_PUBLIC_PRIVACY_EMAIL', DEV_FALLBACKS.privacyEmail)
+}
+
+export function getSupportEmail(): string {
+  return readOrThrow('NEXT_PUBLIC_SUPPORT_EMAIL', DEV_FALLBACKS.supportEmail)
+}
+
+export function getLegalEmail(): string {
+  return readOrThrow('NEXT_PUBLIC_LEGAL_EMAIL', DEV_FALLBACKS.legalEmail)
+}
+
+// Soft (returns '' when unset) — pages hide the address block instead
+// of throwing so staging can deploy before the postal address is finalised.
+export function getCompanyAddress(): string {
+  return (process.env.NEXT_PUBLIC_COMPANY_ADDRESS ?? '').trim()
+}


### PR DESCRIPTION
## Why

<!-- What problem does this PR solve? Link to the issue. -->

Closes #

## What changed

<!-- List the key changes. Be specific. -->

-

## How to test

<!-- Steps to verify the change works correctly. -->

1.

## Checklist

- [ ] No `any` types in TypeScript
- [ ] `pnpm lint` passes
- [ ] `pnpm build` passes locally
- [ ] Self-reviewed the diff before opening PR
- [ ] QA: affected `docs/qa/**.md` test cases updated (or N/A — purely internal change)
- [ ] Admin help: if a touched admin form added/removed/renamed any field, the matching `docs/admin-help/**.md` is updated in the same PR (or N/A)
