### PR TITLE
chore: Lighthouse audit baseline + fix CLS 0.92 and CSP worker-src (#…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,7 +27,8 @@ coverage
 
 # JUnit test reports — generated per-run by jest-junit (api) and vitest junit
 # reporter (web). Read by CI (dorny/test-reporter) and discarded after.
-reports/
+# Anchored to /reports/ so docs/reports/ (checked-in audit reports) stays tracked.
+/reports/
 apps/*/reports/
 
 # Allure raw results + generated HTML report (#252). Produced only on CI
@@ -168,3 +169,4 @@ apps/api/src/prisma/generated
 package-lock.json
 yarn.lock
 .claude/settings.json
+docs/reports/lighthouse-runs/

--- a/apps/web/src/app/[locale]/account/_components/account-auth-guard.tsx
+++ b/apps/web/src/app/[locale]/account/_components/account-auth-guard.tsx
@@ -8,12 +8,8 @@ interface AccountAuthGuardProps {
   children: React.ReactNode
 }
 
-/**
- * Client-side authentication guard for /account/* routes.
- * Redirects unauthenticated users to /login.
- * isHydrated flag prevents premature redirect before Zustand rehydrates from
- * localStorage — same pattern as AdminAuthGuard.
- */
+// Placeholder (not `null`) reserves viewport height so the footer doesn't
+// jump when children replace it — was CLS 0.92 on /account/* pre-hydration.
 export function AccountAuthGuard({ children }: AccountAuthGuardProps) {
   const isAuthenticated = useAuthStore((state) => state.isAuthenticated)
   const router = useRouter()
@@ -30,7 +26,7 @@ export function AccountAuthGuard({ children }: AccountAuthGuardProps) {
   }, [isHydrated, isAuthenticated, router])
 
   if (!isHydrated || !isAuthenticated) {
-    return null
+    return <div aria-hidden="true" className="min-h-screen" />
   }
 
   return <>{children}</>

--- a/apps/web/src/app/[locale]/admin/_components/__tests__/admin-auth-guard.test.tsx
+++ b/apps/web/src/app/[locale]/admin/_components/__tests__/admin-auth-guard.test.tsx
@@ -52,34 +52,36 @@ describe('AdminAuthGuard', () => {
     expect(screen.getByText('Admin content')).toBeInTheDocument()
   })
 
-  it('renders nothing when user is not authenticated', async () => {
+  it('renders a viewport-height placeholder (not empty) when user is not authenticated', async () => {
     mockAuthState(false, null)
 
-    let container!: HTMLElement
     await act(async () => {
-      ;({ container } = render(
+      render(
         <AdminAuthGuard>
           <div>Admin content</div>
         </AdminAuthGuard>,
-      ))
+      )
     })
 
-    expect(container).toBeEmptyDOMElement()
+    expect(screen.queryByText('Admin content')).not.toBeInTheDocument()
+    // Placeholder reserves height so the footer doesn't jump on hydration (CLS fix).
+    const placeholder = document.querySelector('div[aria-hidden="true"]')
+    expect(placeholder).toHaveClass('min-h-screen')
   })
 
-  it('renders nothing when user has USER role', async () => {
+  it('renders the placeholder (not children) when user has USER role', async () => {
     mockAuthState(true, 'USER')
 
-    let container!: HTMLElement
     await act(async () => {
-      ;({ container } = render(
+      render(
         <AdminAuthGuard>
           <div>Admin content</div>
         </AdminAuthGuard>,
-      ))
+      )
     })
 
-    expect(container).toBeEmptyDOMElement()
+    expect(screen.queryByText('Admin content')).not.toBeInTheDocument()
+    expect(document.querySelector('div[aria-hidden="true"]')).toBeInTheDocument()
   })
 
   it('redirects to / when user is not authenticated', async () => {

--- a/apps/web/src/app/[locale]/admin/_components/admin-auth-guard.tsx
+++ b/apps/web/src/app/[locale]/admin/_components/admin-auth-guard.tsx
@@ -28,7 +28,7 @@ export function AdminAuthGuard({ children }: AdminAuthGuardProps) {
   }, [isHydrated, isAuthenticated, role, router])
 
   if (!isHydrated || !isAuthenticated || role !== 'ADMIN') {
-    return null
+    return <div aria-hidden="true" className="min-h-screen" />
   }
 
   return <>{children}</>

--- a/apps/web/src/lib/__tests__/security-headers.test.ts
+++ b/apps/web/src/lib/__tests__/security-headers.test.ts
@@ -46,6 +46,7 @@ describe('getSecurityHeaders — production-only headers', () => {
     expect(csp).toContain("style-src 'self' 'unsafe-inline'")
     expect(csp).toContain("font-src 'self' data:")
     expect(csp).toContain('frame-src')
+    expect(csp).toContain("worker-src 'self' blob:")
     expect(csp).toContain("object-src 'none'")
     expect(csp).toContain("base-uri 'self'")
     expect(csp).toContain("form-action 'self'")

--- a/apps/web/src/lib/security-headers.ts
+++ b/apps/web/src/lib/security-headers.ts
@@ -46,6 +46,8 @@ function buildContentSecurityPolicy(): string {
     "style-src 'self' 'unsafe-inline'",
     "font-src 'self' data:",
     `frame-src ${FRAME_SRC_HOSTS.join(' ')}`,
+    // Stripe Elements spawns a worker from a blob: URL for card tokenisation.
+    "worker-src 'self' blob:",
     "object-src 'none'",
     "base-uri 'self'",
     "form-action 'self'",

--- a/docs/reports/lighthouse-2026-07.md
+++ b/docs/reports/lighthouse-2026-07.md
@@ -1,0 +1,110 @@
+# Lighthouse + CWV audit — 2026-07 (#360)
+
+Baseline snapshot after 6 months of feature work since the previous audit
+(#38, closed 2026-Q1). Prod build served from `next start`, no CDN,
+mobile emulation, slow-4G throttling, Lighthouse `--preset=perf`.
+
+## Setup
+
+- Web build: `pnpm --filter web build` (Turbopack disabled).
+- Web served: `next start -p 3100`.
+- API: `pnpm --filter api dev` on :4000 with the local Postgres seed.
+- Lighthouse CLI: `pnpm dlx lighthouse 13.4.0`, mobile form factor, simulated
+  slow-4G throttling, headless Chromium.
+- Raw JSON runs are kept under `docs/reports/lighthouse-runs/` (gitignored;
+  regenerate with the commands in the "How to re-run" section).
+
+Targets from AC:
+- Performance ≥ 90 (mobile), Accessibility ≥ 95, SEO = 100 (except
+  `/checkout`, which is `noindex`).
+- LCP < 2.5 s · CLS < 0.1 · TTFB < 800 ms · TBT proxying INP < 200 ms.
+
+## Baseline (before this PR)
+
+| Page             | Perf | A11y | BP | SEO | LCP    | FCP    | TBT   | CLS   |
+| ---------------- | ---- | ---- | -- | --- | ------ | ------ | ----- | ----- |
+| /en              | 79   | 97   | 88 | 92  | 5381ms | 1063ms | 81ms  | 0.000 |
+| /en/products/... | 77   | 94   | 88 | 92  | 6538ms | 1060ms | 99ms  | 0.000 |
+| /en/checkout     | 72   | 97   | 69 | 92  | 6511ms | 909ms  | 248ms | 0.000 |
+| /en/account/orders | 53 | 97   | 88 | 92  | 6246ms | 916ms  | 86ms  | 0.921 |
+| /en/about        | 77   | 97   | 88 | 92  | 5841ms | 1057ms | 154ms | 0.000 |
+
+## Fixed in this PR
+
+Two regressions were cheap enough to fix in-scope. Everything else is filed
+as a follow-up issue below (LCP / bundle work needs its own week).
+
+### 1. CLS 0.92 → 0 on `/account/*` and `/admin/*`
+
+`AccountAuthGuard` / `AdminAuthGuard` returned `null` before Zustand
+rehydrated `accessToken` from `localStorage`. That left the footer glued
+to the header on first paint; when hydration decided "authenticated" (or
+kicked off a redirect) the layout jumped ~1 viewport downward.
+
+Fix: guards now return a `min-h-screen` placeholder instead of `null`, so
+the reserved space matches the eventual content and the footer stays put.
+
+Confirmed with a fresh Lighthouse run: `/en/account/orders` CLS
+`0.921 → 0.000`, Performance `53 → 79`.
+
+### 2. `worker-src` missing in production CSP
+
+Stripe Elements spawns a Web Worker from a `blob:` URL. The prod CSP had
+no `worker-src` directive, so it fell back to `default-src 'self'` and the
+worker was blocked, emitting a violation into the console — Lighthouse
+counted this against Best-Practices on `/checkout` (69) and any page
+served with the strict headers.
+
+Fix: added `worker-src 'self' blob:` to `buildContentSecurityPolicy()`.
+After: `/en/checkout` Best-Practices `69 → 73`, home BP `88 → 96`.
+
+## Remaining gaps → follow-up issues
+
+None of these are cheap in-scope fixes; each is filed as its own issue.
+
+| Symptom                                     | Follow-up |
+| ------------------------------------------- | --------- |
+| LCP 5.3–6.5 s on every page (target 2.5 s)  | (see #364) |
+| Unused JavaScript 138–337 KiB per page      | (see #365) |
+| Header/footer logo aspect-ratio mismatch    | (see #366) |
+| `meta-description` reported missing by LH even though the tag is present in the SSR HTML | (see #367) |
+
+## How to re-run
+
+```bash
+# 1. boot the local stack
+export NO_PROXY='localhost,127.0.0.1,::1'  # if you use a corp HTTP proxy
+docker start jewelry_postgres              # if not already running
+pnpm --filter api dev &                    # :4000
+pnpm --filter web build
+pnpm --filter web exec next start -p 3100 &
+
+# 2. run Lighthouse against the five key pages
+mkdir -p docs/reports/lighthouse-runs && cd docs/reports/lighthouse-runs
+for pair in \
+  "home:/en" \
+  "product:/en/products/black-onyx-statement-pendant" \
+  "checkout:/en/checkout" \
+  "account-orders:/en/account/orders" \
+  "about:/en/about"; do
+  slug=${pair%%:*}; path=${pair##*:}
+  pnpm dlx lighthouse "http://localhost:3100${path}" \
+    --preset=perf --form-factor=mobile --screenEmulation.mobile=true \
+    --throttling-method=simulate \
+    --only-categories=performance,accessibility,best-practices,seo \
+    --output=json --output-path="./${slug}.json" \
+    --chrome-flags="--headless=new --no-sandbox" --quiet
+done
+```
+
+## Local-run caveats
+
+- No CDN in front, so LCP is uniformly pessimistic vs. a real Vercel deploy
+  (edge cache would shave several hundred ms off cold TTFB). Treat these
+  numbers as a floor for the metrics, not the ceiling.
+- INP is not measured — Lighthouse reports TBT as a proxy. Real INP will
+  need RUM (PostHog web-vitals or CrUX) after launch.
+- Meta-description shows as failing on `/en`, `/en/checkout`, and
+  `/en/products/...` even though `<meta name="description">` is present in
+  the initial HTML. Reproducibly wrong across two Lighthouse presets;
+  tracking in the follow-up issue rather than trying to silence the score.


### PR DESCRIPTION
…360)

## Why

<!-- What problem does this PR solve? Link to the issue. -->

Closes #

## What changed

<!-- List the key changes. Be specific. -->

-

## How to test

<!-- Steps to verify the change works correctly. -->

1.

## Checklist

- [ ] No `any` types in TypeScript
- [ ] `pnpm lint` passes
- [ ] `pnpm build` passes locally
- [ ] Self-reviewed the diff before opening PR
- [ ] QA: affected `docs/qa/**.md` test cases updated (or N/A — purely internal change)
- [ ] Admin help: if a touched admin form added/removed/renamed any field, the matching `docs/admin-help/**.md` is updated in the same PR (or N/A)
